### PR TITLE
Added functionality to be able to learn partial matrices

### DIFF
--- a/src/e3nn_matrix/data/irreps_tools.py
+++ b/src/e3nn_matrix/data/irreps_tools.py
@@ -26,6 +26,9 @@ def get_atom_irreps(atom: sisl.Atom):
         the basis irreps.
     """
 
+    if atom.no == 0:
+        return o3.Irreps("")
+
     atom_irreps = []
 
     # Array that stores the number of orbitals for each l.

--- a/src/e3nn_matrix/data/matrices/basis_matrix.py
+++ b/src/e3nn_matrix/data/matrices/basis_matrix.py
@@ -64,9 +64,14 @@ class BasisMatrix:
             blocks = [
                 (self.block_dict[i, i, 0] - point_matrices[point_types[i]]).flatten()
                 for i in order
+                if self.basis_count[i] > 0
             ]
         else:
-            blocks = [self.block_dict[i, i, 0].flatten() for i in order]
+            blocks = [
+                self.block_dict[i, i, 0].flatten()
+                for i in order
+                if self.basis_count[i] > 0
+            ]
 
         node_values = np.concatenate(blocks)
 
@@ -74,6 +79,7 @@ class BasisMatrix:
         blocks = [
             self.block_dict[edge[0], edge[1], sc_shift].flatten()
             for edge, sc_shift in zip(edge_index.transpose(), edge_sc_shifts)
+            if self.basis_count[edge[0]] > 0 and self.basis_count[edge[1]] > 0
         ]
 
         edge_values = np.concatenate(blocks)

--- a/src/e3nn_matrix/data/node_feats.py
+++ b/src/e3nn_matrix/data/node_feats.py
@@ -1,0 +1,132 @@
+from typing import Callable, Optional
+
+import numpy as np
+
+class NodeFeature:
+
+    def __new__(cls, config, data_processor):
+        return cls.get_feature(config, data_processor)
+
+    registry = {}
+
+    def __init_subclass__(cls) -> None:
+        NodeFeature.registry[cls.__name__] = cls
+
+    @staticmethod
+    def get_feature(config: dict, data_processor) -> np.ndarray:
+        raise NotImplementedError
+    
+    @staticmethod
+    def get_irreps(data_processor):
+        raise NotImplementedError
+        
+class OneHotZ(NodeFeature):
+
+    @staticmethod
+    def get_irreps(basis_table):
+        from e3nn import o3
+        return o3.Irreps([(len(basis_table), (0, 1))])
+
+    @staticmethod
+    def get_feature(config, data_processor):
+        indices = data_processor.get_point_types(config)
+        return data_processor.one_hot_encode(indices)
+
+class WaterDipole(NodeFeature):
+
+    @staticmethod
+    def get_irreps(basis_table):
+        from e3nn import o3
+        return o3.Irreps("1x1o")
+
+    @staticmethod
+    def get_feature(config, data_processor):
+
+        n_atoms = len(config.positions)
+
+        z_dipole = np.array([0.0, 0.0, 0.0])
+        for position, point_type in zip(config.positions, config.point_types):
+            if point_type == 8 or point_type == 1:
+
+                z_dipole[2] += position[2]*(-2 if point_type == 8 else 1)
+        
+        z_dipole = data_processor.cartesian_to_basis(z_dipole) / 30
+        z_dipole = np.tile(z_dipole, n_atoms).reshape(n_atoms, 3)
+
+        return z_dipole
+    
+class WaterDipoleInv(NodeFeature):
+
+    @staticmethod
+    def get_irreps(basis_table):
+        from e3nn import o3
+        return o3.Irreps("1x0e")
+
+    @staticmethod
+    def get_feature(config, data_processor):
+
+        n_atoms = len(config.positions)
+
+        z_dipole = np.array([0.0])
+        for position, point_type in zip(config.positions, config.point_types):
+            if point_type == 8 or point_type == 1:
+
+                z_dipole[0] += position[2]*(-2 if point_type == 8 else 1)
+        
+        z_dipole = np.tile(z_dipole, n_atoms).reshape(n_atoms, 1)
+
+        return z_dipole / 30
+    
+class Nothing(NodeFeature):
+
+    @staticmethod
+    def get_irreps(basis_table):
+        from e3nn import o3
+        return o3.Irreps("1x0e")
+
+    @staticmethod
+    def get_feature(config, data_processor):
+
+        n_atoms = len(config.positions)
+
+        z_dipole = np.array([0.0])
+        
+        z_dipole = np.tile(z_dipole, n_atoms).reshape(n_atoms, 1)
+
+        return z_dipole 
+    
+class NothingVector(NodeFeature):
+
+    @staticmethod
+    def get_irreps(basis_table):
+        from e3nn import o3
+        return o3.Irreps("1x1o")
+
+    @staticmethod
+    def get_feature(config, data_processor):
+
+        n_atoms = len(config.positions)
+
+        z_dipole = np.array([0.0, 0.0, 0.0])
+        
+        z_dipole = np.tile(z_dipole, n_atoms).reshape(n_atoms, 3)
+
+        return z_dipole 
+    
+class One(NodeFeature):
+
+    @staticmethod
+    def get_irreps(basis_table):
+        from e3nn import o3
+        return o3.Irreps("1x0e")
+
+    @staticmethod
+    def get_feature(config, data_processor):
+
+        n_atoms = len(config.positions)
+
+        z_dipole = np.array([1.0])
+        
+        z_dipole = np.tile(z_dipole, n_atoms).reshape(n_atoms, 1)
+
+        return z_dipole 

--- a/src/e3nn_matrix/data/sparse.py
+++ b/src/e3nn_matrix/data/sparse.py
@@ -3,8 +3,6 @@
 Different sparse representations of a matrix are required during the different
 steps of a typical workflow using ``e3nn_matrix``.
 """
-
-from dataclasses import dataclass
 from typing import Dict, Tuple, Type, Optional
 
 import itertools
@@ -23,13 +21,25 @@ def csr_to_block_dict(
     spmat: sisl.SparseCSR,
     atoms: sisl.Atoms,
     nsc: np.ndarray,
+    geometry_atoms: Optional[sisl.Atoms] = None,
     matrix_cls: Type[OrbitalMatrix] = OrbitalMatrix,
 ) -> OrbitalMatrix:
-    """
-    Creates a OrbitalMatrix object from a SparseCSR matrix
-    In the block dictionary of the OrbitalMatrix:
-    Each key is a 2-tuple of atom indices
-    each value is the corresponding block of the orbital matrix as a dense numpy ndarray
+    """Creates a OrbitalMatrix object from a SparseCSR matrix
+
+    Parameters
+    ----------
+    spmat :
+        The sparse matrix to convert to a block dictionary.
+    atoms :
+        The atoms object for the matrix, containing orbital information.
+    nsc :
+        The auxiliary supercell size.
+    matrix_cls :
+        Matrix class to initialize.
+    geometry_atoms :
+        The atoms object for the full geometry. This allows the matrix to contain
+        atoms without any orbital. Geometry atoms should contain the matrix atoms
+        first and then the orbital-less atoms.
     """
     orbitals = atoms.orbitals
 
@@ -41,6 +51,8 @@ def csr_to_block_dict(
         orbitals=orbitals,
         n_atoms=len(atoms.specie),
     )
+
+    orbitals = geometry_atoms.orbitals if geometry_atoms is not None else atoms.orbitals
 
     return matrix_cls(block_dict=block_dict, nsc=nsc, orbital_count=orbitals)
 

--- a/src/e3nn_matrix/data/tests/test_basis.py
+++ b/src/e3nn_matrix/data/tests/test_basis.py
@@ -9,25 +9,36 @@ from e3nn_matrix.data import PointBasis
 
 
 def test_simplest():
-    basis = PointBasis("A", "spherical", o3.Irreps("3x0e + 2x1o"), 5)
+    basis = PointBasis(
+        "A", basis_convention="spherical", irreps=o3.Irreps("3x0e + 2x1o"), R=5
+    )
 
 
 def test_siesta_convention():
-    basis = PointBasis("A", "siesta_spherical", o3.Irreps("3x0e + 2x1o"), 5)
+    basis = PointBasis(
+        "A", basis_convention="siesta_spherical", irreps=o3.Irreps("3x0e + 2x1o"), R=5
+    )
+
+
+def test_no_basis():
+    basis = PointBasis("A", R=5)
 
 
 def test_multiple_R():
     basis = PointBasis(
         "A",
-        "spherical",
-        o3.Irreps("3x0e + 2x1o"),
-        np.array([5, 5, 5, 3, 3, 3, 3, 3, 3]),
+        basis_convention="spherical",
+        irreps=o3.Irreps("3x0e + 2x1o"),
+        R=np.array([5, 5, 5, 3, 3, 3, 3, 3, 3]),
     )
 
     # Wrong number of Rs
     with pytest.raises(AssertionError):
         basis = PointBasis(
-            "A", "spherical", o3.Irreps("3x0e + 2x1o"), np.array([5, 5, 5, 3, 3])
+            "A",
+            basis_convention="spherical",
+            irreps=o3.Irreps("3x0e + 2x1o"),
+            R=np.array([5, 5, 5, 3, 3]),
         )
 
 
@@ -46,9 +57,9 @@ def test_from_sisl_atom():
 def test_to_sisl_atom():
     basis = PointBasis(
         "A",
-        "siesta_spherical",
-        o3.Irreps("3x0e + 2x1o"),
-        np.array([5, 5, 5, 3, 3, 3, 3, 3, 3]),
+        basis_convention="siesta_spherical",
+        irreps=o3.Irreps("3x0e + 2x1o"),
+        R=np.array([5, 5, 5, 3, 3, 3, 3, 3, 3]),
     )
 
     atom = basis.to_sisl_atom()

--- a/src/e3nn_matrix/tools/lightning/models/mace.py
+++ b/src/e3nn_matrix/tools/lightning/models/mace.py
@@ -1,4 +1,4 @@
-from typing import Type, Union
+from typing import Type, Union, Optional
 
 from e3nn import o3
 import torch
@@ -30,6 +30,7 @@ class LitOrbitalMatrixMACE(LitBasisMatrixModel):
         root_dir: str = ".",
         basis_files: Union[str, None] = None,
         basis_table: Union[BasisTableWithEdges, None] = None,
+        no_basis: Optional[dict] = None,
         # r_max: float=3.0,
         num_bessel: int = 10,
         num_polynomial_cutoff: int = 3,
@@ -45,6 +46,7 @@ class LitOrbitalMatrixMACE(LitBasisMatrixModel):
         avg_num_neighbors: float = 1.0,
         # atomic_numbers: List[int],
         correlation: int = 1,
+        initial_node_feats: str = "OneHotZ",
         # unique_atoms: Sequence[sisl.Atom],
         matrix_readout: Type[MACEBasisMatrixReadout] = MACEBasisMatrixReadout,
         symmetric_matrix: bool = False,
@@ -60,7 +62,9 @@ class LitOrbitalMatrixMACE(LitBasisMatrixModel):
             root_dir=root_dir,
             basis_files=basis_files,
             basis_table=basis_table,
+            no_basis=no_basis,
             loss=loss,
+            initial_node_feats=initial_node_feats,
             model_cls=OrbitalMatrixMACE,
         )
         self.save_hyperparameters()
@@ -89,6 +93,7 @@ class LitOrbitalMatrixMACE(LitBasisMatrixModel):
             node_block_readout=node_block_readout,
             edge_block_readout=edge_block_readout,
             only_last_readout=only_last_readout,
+            node_attr_irreps=self.initial_node_feats_irreps,
         )
 
     def configure_optimizers(self):

--- a/src/e3nn_matrix/tools/server/server_app.py
+++ b/src/e3nn_matrix/tools/server/server_app.py
@@ -228,22 +228,7 @@ def create_server_app(
         }
 
     def predict_from_geometry(model, geometry):
-        with torch.no_grad():
-            # USE THE MODEL
-            # First, we need to process the input data, to get inputs as the model expects.
-            input_data = BasisMatrixTorchData.new(
-                geometry, data_processor=model["data_processor"], labels=False
-            )
-
-            # Then, we run the model.
-            out = model["prediction_function"](input_data)
-
-            # And finally, we convert the output to a matrix.
-            matrix = model["data_processor"].matrix_from_data(
-                input_data, predictions=out
-            )
-
-        return matrix
+        return model["data_processor"].torch_predict(model["prediction_function"], geometry)
 
     @api.post("/models/{model_name}/predict", response_class=FileResponse)
     async def predict(

--- a/src/e3nn_matrix/torch/conftest.py
+++ b/src/e3nn_matrix/torch/conftest.py
@@ -18,17 +18,26 @@ from e3nn_matrix.torch.data import BasisMatrixTorchData
 from e3nn_matrix.torch.modules import BasisMatrixReadout
 
 
-@pytest.fixture(scope="module", params=[True, False])
-def long_A_basis(request):
+@pytest.fixture(scope="module", params=["normal", "long_A", "nobasis_A"])
+def basis_type(request):
     return request.param
 
 
 @pytest.fixture(scope="module")
-def ABA_basis_configuration(long_A_basis):
+def ABA_basis_configuration(basis_type):
     """Dummy basis configuration with"""
 
-    point_1 = PointBasis("A", "spherical", o3.Irreps("0e"), R=5 if long_A_basis else 2)
-    point_2 = PointBasis("B", "spherical", o3.Irreps("1o"), R=5)
+    if basis_type == "nobasis_A":
+        point_1 = PointBasis("A", R=5)
+    else:
+        point_1 = PointBasis(
+            "A",
+            R=5 if basis_type == "long_A" else 2,
+            irreps=o3.Irreps("0e"),
+            basis_convention="spherical",
+        )
+
+    point_2 = PointBasis("B", R=5, irreps=o3.Irreps("1o"), basis_convention="spherical")
 
     positions = np.array([[0, 0, 0], [3.0, 0, 0], [5.0, 0, 0]])
 

--- a/src/e3nn_matrix/torch/data.py
+++ b/src/e3nn_matrix/torch/data.py
@@ -49,7 +49,9 @@ class BasisMatrixTorchData(BasisMatrixData, Data):
         return Data.__getitem__(self, key)
 
     def process_input_array(self, key: str, array: np.ndarray) -> Any:
-        if issubclass(array.dtype.type, float):
+        if isinstance(array, torch.Tensor):
+            return array
+        elif issubclass(array.dtype.type, float):
             return torch.tensor(array, dtype=torch.get_default_dtype())
         else:
             return torch.tensor(array)
@@ -59,3 +61,13 @@ class BasisMatrixTorchData(BasisMatrixData, Data):
             return array.numpy(force=True)
         else:
             return np.array(array)
+
+    def is_node_attr(self, key: str) -> bool:
+        return key in self._node_attr_keys
+
+    def is_edge_attr(self, key: str) -> bool:
+        return key in self._edge_attr_keys
+
+    @property
+    def _data(self):
+        return {**self._store}

--- a/src/e3nn_matrix/torch/dataset.py
+++ b/src/e3nn_matrix/torch/dataset.py
@@ -11,7 +11,7 @@ import torch.utils.data
 
 from ..data import BasisConfiguration
 from ..data.processing import MatrixDataProcessor
-from .data import BasisMatrixTorchData
+from .data import BasisMatrixTorchData 
 
 
 class BasisMatrixDataset(torch.utils.data.Dataset):

--- a/src/e3nn_matrix/torch/load.py
+++ b/src/e3nn_matrix/torch/load.py
@@ -99,6 +99,7 @@ def load_from_lit_ckpt(
         sub_point_matrix=ckpt["datamodule_hyper_parameters"]["sub_point_matrix"],
         symmetric_matrix=ckpt["datamodule_hyper_parameters"]["symmetric_matrix"],
         basis_table=ckpt["basis_table"],
+        node_attr_getters=model.initial_node_feats,
     )
 
     return model, data_processor

--- a/src/e3nn_matrix/torch/modules/tests/test_basis_matrix.py
+++ b/src/e3nn_matrix/torch/modules/tests/test_basis_matrix.py
@@ -43,7 +43,7 @@ def test_irreps_in(ABA_basis_configuration: BasisConfiguration):
     assert str(readout) == str(readout2)
 
 
-def test_readout(ABA_basis_configuration: BasisConfiguration, long_A_basis: bool):
+def test_readout(ABA_basis_configuration: BasisConfiguration, basis_type: str):
     config = ABA_basis_configuration
     basis = ABA_basis_configuration.basis
 
@@ -89,12 +89,12 @@ def test_readout(ABA_basis_configuration: BasisConfiguration, long_A_basis: bool
     )
 
     assert isinstance(matrix, csr_matrix)
-    assert matrix.shape == (5, 5)
-    assert matrix.nnz == 25 if long_A_basis else 23
+    assert matrix.shape == (5, 5) if basis_type != "nobasis_A" else (3, 3)
+    assert matrix.nnz == {"normal": 23, "long_A": 25, "nobasis_A": 9}[basis_type]
 
 
 def test_readout_filtering(
-    ABA_basis_configuration: BasisConfiguration, long_A_basis: bool
+    ABA_basis_configuration: BasisConfiguration, basis_type: str
 ):
     config = ABA_basis_configuration
     basis = ABA_basis_configuration.basis
@@ -182,5 +182,5 @@ def test_readout_filtering(
     )
 
     assert isinstance(matrix, csr_matrix)
-    assert matrix.shape == (5, 5)
-    assert matrix.nnz == 25 if long_A_basis else 23
+    assert matrix.shape == (5, 5) if basis_type != "nobasis_A" else (3, 3)
+    assert matrix.nnz == {"normal": 23, "long_A": 25, "nobasis_A": 9}[basis_type]


### PR DESCRIPTION
This is useful for example in QM/MM setups, where you might use the full graph but you only want to learn the matrix for the QM region.

Some documentation is missing, will add it after I refactor the whole repo (to rename it from `e3nn_matrix` to `graph2mat`).