### PR TITLE
New paradigm for handling all the different formats.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ build/
 # Docs
 docs/build
 docs/api/api-generated
+docs/api/conversions.rst
 
 # Jupyter notebook checkpoints
 **/.ipynb_checkpoints

--- a/docs/_static/css/custom_styles.css
+++ b/docs/_static/css/custom_styles.css
@@ -46,3 +46,18 @@ div.nbinput .prompt, div.nboutput .prompt {
 div.nblast.container {
     margin-bottom: 24px;
 }
+
+/* Format the header of conversion functions */
+div.g2m-conversion-func-header {
+    padding: 5px;
+    background-color: rgb(196, 252, 191);
+}
+
+div.g2m-conversion-func-header p {
+    padding: 0;
+    margin: 0;
+}
+
+div.g2m-conversion-func-header + dl.py.function dt{
+    scroll-margin-top: 50px;
+}

--- a/docs/api/description.rst
+++ b/docs/api/description.rst
@@ -73,18 +73,44 @@ These classes are used to store the data of your dataset.
 `BasisConfiguration` and `OrbitalConfiguration` are used to store the raw information
 of a structure, including its coordinates, atomic numbers and corresponing matrix.
 
-`BasisMatrixData` is a container that stores the configuration in the shape of a graph,
+`BasisMatrixDataBase` (and its subclasses) is a container that stores the configuration in the shape of a graph,
 ready to be used by models. It contains, for example, information about the edges. This
-class is ready to be batched. It uses `numpy` arrays, therefore to use it in `torch` you
-need to use the extension provided in `graph2mat.bindings.torch`.
+class is ready to be batched. However, the `BasisMatrixDataBase` class is just a base class
+and you are never going to use it directly. Instead, you will use a subclass of it that handles
+a given type of arrays (e.g. `numpy` arrays, `torch` tensors...). The core library provides
+one for `numpy` arrays, `BasisMatrixData`. For the variant that deals with `torch` tensors
+for example, you will need to use the subclass provided in `graph2mat.bindings.torch`.
 
 .. autosummary::
     :toctree: api-generated/
     :template: autosummary/custom-class-template.rst
 
+    BasisMatrixDataBase
     BasisMatrixData
     BasisConfiguration
     OrbitalConfiguration
+
+Formats
+*******
+
+Handling sparse matrices for associated 3D point clouds with basis functions is sometimes
+not straightforward. For each different task (e.g. training a ML model, computing a property...)
+there might be some data format that is more convenient. To the user (and the developer), converting
+from any format to any other target format can be a pain. In `graph2mat`, we try to centralize
+this task by:
+
+- Having a class, `Formats`, that contains all the formats that we support.
+- Having a class that manages the conversions between these formats: `ConversionManager``.
+
+An instance of `ConversionManager` is available at ``graph2mat.conversions``, which all
+the conversions implemented by graph2mat. See them here: :ref:`g2m.conversions`.
+
+.. autosummary::
+    :toctree: api-generated/
+    :template: autosummary/custom-class-template.rst
+
+    Formats
+    ConversionManager
 
 Other useful top level modules
 *******************************

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,6 +66,7 @@ extensions = [
 ]
 napoleon_numpy_docstring = True
 napoleon_use_param = True
+napoleon_custom_sections = ["Haha"]
 
 # There currently is a bug with mathjax >= 3, so we resort to 2.7.7
 # mathjax_path = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/latest.js?config=TeX-AMS-MML_HTMLorMML"
@@ -233,3 +234,99 @@ intersphinx_mapping = {
     "torch": ("https://pytorch.org/docs/stable/", None),
     "e3nn": ("https://docs.e3nn.org/en/stable/", None),
 }
+
+# Write the documentation for available conversions.
+
+from graph2mat import conversions
+from graph2mat.bindings.torch import *
+
+docs_root = pathlib.Path(__file__).parent
+# Write the conversion functions to a file
+with open(docs_root / "api" / "conversions.rst", "w") as f:
+    f.write(
+        """
+.. _g2m.conversions:
+
+Format conversions
+==================
+
+When `graph2mat` is initialized, a global `graph2mat.ConversionManager` is created and made available
+at `graph2mat.conversions`. It can be imported like:
+
+.. code-block:: python
+
+    import graph2mat
+    # Use it like
+    graph2mat.conversions
+
+    # Or alternatively
+    from graph2mat import conversions
+
+This conversion manager contains all the conversions between formats implemented in `graph2mat`.
+
+.. note::
+    See the documentation of `graph2mat.ConversionManager` for some remarks on how to
+    access/use the existing converters, as well as how to add new ones.
+
+.. currentmodule:: graph2mat.conversions
+
+Summary of available conversions
+--------------------------------
+
+The following table summarizes all the available conversions.
+Each row contains:
+
+- **Source**: The format to convert from.
+- **Target**: The format to convert to.
+- **Function**: The function that performs the conversion, click on it to go to its documentation.
+
+See `graph2mat.Formats` for a list of all available formats, together with
+a description of what each format is.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 20 20 60
+
+    * - Source
+      - Target
+      - Function
+
+"""
+    )
+    converters_list = list(
+        (source, target, f"{source}_to_{target}", converter)
+        for (source, target), converter in sorted(conversions._converters.items())
+    )
+
+    for source, target, func_name, converter in converters_list:
+        f.write(
+            f"""
+    * - {source}
+      - {target}
+      - :func:`{func_name}`
+"""
+        )
+
+    f.write(
+        """
+
+Documentation of conversion functions
+-------------------------------------
+
+"""
+    )
+    # Write a list with all available conversions and a link to the function
+    for source, target, func_name, converter in converters_list:
+        source_format = Formats.string_to_attr_name(source)
+        target_format = Formats.string_to_attr_name(target)
+
+        f.write(
+            f"""
+
+.. container:: g2m-conversion-func-header
+
+    :func:`Formats.{source_format}` -> :func:`Formats.{target_format}`\n\n
+
+"""
+        )
+        f.write(f".. autofunction:: {func_name}\n")

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -69,4 +69,5 @@ powerful applications that take full advantage of the properties of these matric
    :hidden:
 
    api/description
+   api/conversions
    api/full_api

--- a/docs/tutorials/python_api/Computing a matrix.ipynb
+++ b/docs/tutorials/python_api/Computing a matrix.ipynb
@@ -622,7 +622,7 @@
    "source": [
     "This is a `scipy` sparse matrix. If you are not familiar with sparse matrices, they are just an efficient way of storing matrices with many zeros.\n",
     "\n",
-    "You can actually convert them to a dense `numpy` array:"
+    "You can also specify the `out_format` argument to for any other supported output format (see the `graph2mat.Formats` documentation for all the supported formats). For example, you can ask for a torch tensor:"
    ]
   },
   {
@@ -632,7 +632,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "matrix.toarray()"
+    "processor.matrix_from_data(\n",
+    "    data,\n",
+    "    predictions={\"node_labels\": node_labels, \"edge_labels\": edge_labels},\n",
+    "    out_format=\"torch\",\n",
+    ")"
    ]
   },
   {
@@ -714,7 +718,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "graph2mat",
    "language": "python",
    "name": "python3"
   },
@@ -728,7 +732,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.19"
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ docs = [
     "pyyaml",
     "fastapi",
     "uvicorn",
-    "plotly",
+    "plotly<6", # Until https://github.com/plotly/plotly.py/issues/5056 is fixed
     "pandas",
     "pytorch-lightning",
     "jsonargparse[signatures]",

--- a/src/graph2mat/bindings/torch/data/__init__.py
+++ b/src/graph2mat/bindings/torch/data/__init__.py
@@ -2,3 +2,4 @@
 
 from .data import *
 from .dataset import *
+from .formats import *

--- a/src/graph2mat/bindings/torch/data/data.py
+++ b/src/graph2mat/bindings/torch/data/data.py
@@ -1,75 +1,40 @@
 """Implements the Data class to use in pytorch models."""
-from __future__ import annotations
-
-from typing import Dict, Any
-
-import numpy as np
+from typing import Any, Optional
 
 import torch
 
 from torch_geometric.data.data import Data
 
-from graph2mat import BasisMatrixData
+from graph2mat.core.data import Formats, conversions
+from graph2mat.core.data.processing import BasisMatrixDataBase, BasisMatrixData
 
 __all__ = ["TorchBasisMatrixData"]
 
 
-class TorchBasisMatrixData(BasisMatrixData, Data):
-    """Extension of `BasisMatrixData` to be used within pytorch.
+class TorchBasisMatrixData(BasisMatrixDataBase[torch.Tensor], Data):
+    """Extension of ``BasisMatrixDataBase`` to be used within pytorch.
 
     All this class implements is the conversion of numpy arrays to torch tensors
-    and back. The rest of the functionality is inherited from `BasisMatrixData`.
+    and back. The rest of the functionality is inherited from ``BasisMatrixDataBase``.
 
-    Please refer to the documentation of `BasisMatrixData` for more information.
+    Please refer to the documentation of ``BasisMatrixDataBase`` for more information.
 
     See Also
     --------
-    BasisMatrixData
+    graph2mat.BasisMatrixDataBase
         The class that implements the heavy lifting of the data processing.
     """
 
-    num_nodes: torch.Tensor
-    edge_index: torch.Tensor
-    neigh_isc: torch.Tensor
-    node_attrs: torch.Tensor
-    positions: torch.Tensor
-    shifts: torch.Tensor
-    cell: torch.Tensor
-    n_supercells: torch.Tensor
-    nsc: torch.Tensor
-    point_labels: torch.Tensor
-    edge_labels: torch.Tensor
-    point_types: torch.Tensor
-    edge_types: torch.Tensor
-    edge_type_nlabels: torch.Tensor
-    metadata: Dict[str, Any]
+    _format = Formats.TORCH_BASISMATRIXDATA
+    _data_format = Formats.TORCH_NODESEDGES
+    _array_format = Formats.TORCH
 
     def __init__(self, *args, **kwargs):
-        data = BasisMatrixData._sanitize_data(self, **kwargs)
+        data = BasisMatrixDataBase._sanitize_data(self, **kwargs)
         Data.__init__(self, **data)
 
     def __getitem__(self, key: str) -> Any:
         return Data.__getitem__(self, key)
-
-    def process_input_array(self, key: str, array: np.ndarray) -> Any:
-        if isinstance(array, torch.Tensor):
-            return array
-        elif issubclass(array.dtype.type, float):
-            return torch.tensor(array, dtype=torch.get_default_dtype())
-        else:
-            return torch.tensor(array)
-
-    def ensure_numpy(self, array: torch.Tensor) -> np.ndarray:
-        if isinstance(array, torch.Tensor):
-            return array.numpy(force=True)
-        else:
-            return np.array(array)
-
-    def is_node_attr(self, key: str) -> bool:
-        return key in self._node_attr_keys
-
-    def is_edge_attr(self, key: str) -> bool:
-        return key in self._edge_attr_keys
 
     @property
     def _data(self):

--- a/src/graph2mat/bindings/torch/data/formats.py
+++ b/src/graph2mat/bindings/torch/data/formats.py
@@ -1,0 +1,108 @@
+"""Extensions to the registered formats/conversions for ``torch`` tensors."""
+
+from typing import Optional
+
+import torch
+import numpy as np
+
+from graph2mat.core.data import conversions, Formats
+from graph2mat.core.data.sparse import _nodes_and_edges_to_coo
+
+Formats.add_alias(Formats.TORCH, torch.Tensor)
+Formats.add_alias(Formats.TORCH_COO, torch.sparse_coo_tensor)
+Formats.add_alias(Formats.TORCH_CSR, torch.sparse_csr_tensor)
+
+converter = conversions.converter
+
+
+@converter
+def _coo_to_csr(coo: torch.sparse_coo_tensor) -> torch.sparse_csr_tensor:
+    return coo.to_sparse_csr()
+
+
+@converter
+def _coo_to_dense(coo: torch.sparse_coo_tensor) -> torch.Tensor:
+    return coo.to_dense()
+
+
+@converter
+def _csr_to_coo(csr: torch.sparse_csr_tensor) -> torch.sparse_coo_tensor:
+    return csr.to_sparse_coo()
+
+
+@converter
+def _csr_to_dense(csr: torch.sparse_csr_tensor) -> torch.Tensor:
+    return csr.to_dense()
+
+
+@converter
+def _torch_to_numpy(tensor: torch.Tensor) -> np.ndarray:
+    return tensor.numpy(force=True)
+
+
+@converter
+def _numpy_to_torch(array: np.ndarray) -> torch.Tensor:
+    if issubclass(array.dtype.type, float):
+        return torch.tensor(array, dtype=torch.get_default_dtype())
+    else:
+        return torch.tensor(array)
+
+
+@converter(Formats.TORCH_NODESEDGES, Formats.TORCH_COO)
+def nodes_and_edges_to_coo(
+    node_vals: torch.Tensor,
+    edge_vals: torch.Tensor,
+    edge_index: torch.Tensor,
+    orbitals: torch.Tensor,
+    n_supercells: int = 1,
+    edge_neigh_isc: Optional[torch.Tensor] = None,
+    threshold: Optional[float] = None,
+    symmetrize_edges: bool = False,
+) -> torch.sparse_coo_tensor:
+    """Converts an orbital matrix from node and edges array to torch coo.
+
+    Conversions to any other sparse structure can be done once we've got the coo array.
+
+    Parameters
+    ----------
+    node_vals
+        Flat array containing the values of the node blocks.
+        The order of the values is first by node index, then row then column.
+    edge_vals
+        Flat array containing the values of the edge blocks.
+        The order of the values is first by edge index, then row then column.
+    edge_index
+        Array of shape (2, n_edges) containing the indices of the atoms
+        that participate in each edge.
+    orbitals
+        Array of shape (n_nodes, ) containing the number of orbitals for each atom.
+    n_supercells
+        Number of auxiliary supercells.
+    edge_neigh_isc
+        Array of shape (n_edges, ) containing the supercell index of the second atom
+        in each edge with respect to the first atom.
+        If not provided, all interactions are assumed to be in the unit cell.
+    threshold
+        Matrix elements with a value below this number are set to 0.
+    symmetrize_edges
+        whether for each edge only one direction is provided. The edge block for the
+        opposite direction is then created as the transpose.
+    """
+
+    def _init_coo(data, rows, cols, shape):
+        return torch.sparse_coo_tensor(
+            torch.stack([torch.tensor(rows), torch.tensor(cols)]), data, shape
+        )
+
+    return _nodes_and_edges_to_coo(
+        concatenate=torch.concatenate,
+        init_coo=_init_coo,
+        node_vals=node_vals,
+        edge_vals=edge_vals,
+        edge_index=edge_index,
+        orbitals=orbitals,
+        n_supercells=n_supercells,
+        edge_neigh_isc=edge_neigh_isc,
+        threshold=threshold,
+        symmetrize_edges=symmetrize_edges,
+    )

--- a/src/graph2mat/core/_docstrings.py
+++ b/src/graph2mat/core/_docstrings.py
@@ -1,0 +1,791 @@
+"""Utilities to handle docstrings, copied directly from numpydoc/docscrape.py.
+
+We copy this file instead of importing it to avoid a dependency on numpydoc, which in
+turn depends on sphinx. The file can be kept in sync with numpydoc/docscrape.py, but it
+probably won't change much.
+
+Below is the license for the original code:
+
+Copyright (C) 2008-2023 Stefan van der Walt <stefan@mentat.za.net>, Pauli Virtanen <pav@iki.fi>
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in
+    the documentation and/or other materials provided with the
+    distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE."""
+
+import copy
+import inspect
+import pydoc
+import re
+import sys
+import textwrap
+from collections import namedtuple
+from collections.abc import Callable, Mapping
+from functools import cached_property
+from warnings import warn
+
+
+def strip_blank_lines(l):
+    "Remove leading and trailing blank lines from a list of lines"
+    while l and not l[0].strip():
+        del l[0]
+    while l and not l[-1].strip():
+        del l[-1]
+    return l
+
+
+class Reader:
+    """A line-based string reader."""
+
+    def __init__(self, data):
+        """
+        Parameters
+        ----------
+        data : str
+           String with lines separated by '\\n'.
+
+        """
+        if isinstance(data, list):
+            self._str = data
+        else:
+            self._str = data.split("\n")  # store string as list of lines
+
+        self.reset()
+
+    def __getitem__(self, n):
+        return self._str[n]
+
+    def reset(self):
+        self._l = 0  # current line nr
+
+    def read(self):
+        if not self.eof():
+            out = self[self._l]
+            self._l += 1
+            return out
+        else:
+            return ""
+
+    def seek_next_non_empty_line(self):
+        for l in self[self._l :]:
+            if l.strip():
+                break
+            else:
+                self._l += 1
+
+    def eof(self):
+        return self._l >= len(self._str)
+
+    def read_to_condition(self, condition_func):
+        start = self._l
+        for line in self[start:]:
+            if condition_func(line):
+                return self[start : self._l]
+            self._l += 1
+            if self.eof():
+                return self[start : self._l + 1]
+        return []
+
+    def read_to_next_empty_line(self):
+        self.seek_next_non_empty_line()
+
+        def is_empty(line):
+            return not line.strip()
+
+        return self.read_to_condition(is_empty)
+
+    def read_to_next_unindented_line(self):
+        def is_unindented(line):
+            return line.strip() and (len(line.lstrip()) == len(line))
+
+        return self.read_to_condition(is_unindented)
+
+    def peek(self, n=0):
+        if self._l + n < len(self._str):
+            return self[self._l + n]
+        else:
+            return ""
+
+    def is_empty(self):
+        return not "".join(self._str).strip()
+
+
+class ParseError(Exception):
+    def __str__(self):
+        message = self.args[0]
+        if hasattr(self, "docstring"):
+            message = f"{message} in {self.docstring!r}"
+        return message
+
+
+Parameter = namedtuple("Parameter", ["name", "type", "desc"])
+
+
+class NumpyDocString(Mapping):
+    """Parses a numpydoc string to an abstract representation
+
+    Instances define a mapping from section title to structured data.
+
+    """
+
+    sections = {
+        "Signature": "",
+        "Summary": [""],
+        "Extended Summary": [],
+        "Parameters": [],
+        "Attributes": [],
+        "Methods": [],
+        "Returns": [],
+        "Yields": [],
+        "Receives": [],
+        "Other Parameters": [],
+        "Raises": [],
+        "Warns": [],
+        "Warnings": [],
+        "See Also": [],
+        "Notes": [],
+        "References": "",
+        "Examples": "",
+        "index": {},
+    }
+
+    def __init__(self, docstring, config=None):
+        orig_docstring = docstring
+        docstring = textwrap.dedent(docstring).split("\n")
+
+        self._doc = Reader(docstring)
+        self._parsed_data = copy.deepcopy(self.sections)
+
+        try:
+            self._parse()
+        except ParseError as e:
+            e.docstring = orig_docstring
+            raise
+
+    def __getitem__(self, key):
+        return self._parsed_data[key]
+
+    def __setitem__(self, key, val):
+        if key not in self._parsed_data:
+            self._error_location(f"Unknown section {key}", error=False)
+        else:
+            self._parsed_data[key] = val
+
+    def __iter__(self):
+        return iter(self._parsed_data)
+
+    def __len__(self):
+        return len(self._parsed_data)
+
+    def _is_at_section(self):
+        self._doc.seek_next_non_empty_line()
+
+        if self._doc.eof():
+            return False
+
+        l1 = self._doc.peek().strip()  # e.g. Parameters
+
+        if l1.startswith(".. index::"):
+            return True
+
+        l2 = self._doc.peek(1).strip()  # ---------- or ==========
+        if len(l2) >= 3 and (set(l2) in ({"-"}, {"="})) and len(l2) != len(l1):
+            snip = "\n".join(self._doc._str[:2]) + "..."
+            self._error_location(
+                f"potentially wrong underline length... \n{l1} \n{l2} in \n{snip}",
+                error=False,
+            )
+        return l2.startswith("-" * len(l1)) or l2.startswith("=" * len(l1))
+
+    def _strip(self, doc):
+        i = 0
+        j = 0
+        for i, line in enumerate(doc):
+            if line.strip():
+                break
+
+        for j, line in enumerate(doc[::-1]):
+            if line.strip():
+                break
+
+        return doc[i : len(doc) - j]
+
+    def _read_to_next_section(self):
+        section = self._doc.read_to_next_empty_line()
+
+        while not self._is_at_section() and not self._doc.eof():
+            if not self._doc.peek(-1).strip():  # previous line was empty
+                section += [""]
+
+            section += self._doc.read_to_next_empty_line()
+
+        return section
+
+    def _read_sections(self):
+        while not self._doc.eof():
+            data = self._read_to_next_section()
+            name = data[0].strip()
+
+            if name.startswith(".."):  # index section
+                yield name, data[1:]
+            elif len(data) < 2:
+                yield StopIteration
+            else:
+                yield name, self._strip(data[2:])
+
+    def _parse_param_list(self, content, single_element_is_type=False):
+        content = dedent_lines(content)
+        r = Reader(content)
+        params = []
+        while not r.eof():
+            header = r.read().strip()
+            if " : " in header:
+                arg_name, arg_type = header.split(" : ", maxsplit=1)
+            else:
+                # NOTE: param line with single element should never have a
+                # a " :" before the description line, so this should probably
+                # warn.
+                if header.endswith(" :"):
+                    header = header[:-2]
+                if single_element_is_type:
+                    arg_name, arg_type = "", header
+                else:
+                    arg_name, arg_type = header, ""
+
+            desc = r.read_to_next_unindented_line()
+            desc = dedent_lines(desc)
+            desc = strip_blank_lines(desc)
+
+            params.append(Parameter(arg_name, arg_type, desc))
+
+        return params
+
+    # See also supports the following formats.
+    #
+    # <FUNCNAME>
+    # <FUNCNAME> SPACE* COLON SPACE+ <DESC> SPACE*
+    # <FUNCNAME> ( COMMA SPACE+ <FUNCNAME>)+ (COMMA | PERIOD)? SPACE*
+    # <FUNCNAME> ( COMMA SPACE+ <FUNCNAME>)* SPACE* COLON SPACE+ <DESC> SPACE*
+
+    # <FUNCNAME> is one of
+    #   <PLAIN_FUNCNAME>
+    #   COLON <ROLE> COLON BACKTICK <PLAIN_FUNCNAME> BACKTICK
+    # where
+    #   <PLAIN_FUNCNAME> is a legal function name, and
+    #   <ROLE> is any nonempty sequence of word characters.
+    # Examples: func_f1  :meth:`func_h1` :obj:`~baz.obj_r` :class:`class_j`
+    # <DESC> is a string describing the function.
+
+    _role = r":(?P<role>(py:)?\w+):"
+    _funcbacktick = r"`(?P<name>(?:~\w+\.)?[a-zA-Z0-9_\.-]+)`"
+    _funcplain = r"(?P<name2>[a-zA-Z0-9_\.-]+)"
+    _funcname = r"(" + _role + _funcbacktick + r"|" + _funcplain + r")"
+    _funcnamenext = _funcname.replace("role", "rolenext")
+    _funcnamenext = _funcnamenext.replace("name", "namenext")
+    _description = r"(?P<description>\s*:(\s+(?P<desc>\S+.*))?)?\s*$"
+    _func_rgx = re.compile(r"^\s*" + _funcname + r"\s*")
+    _line_rgx = re.compile(
+        r"^\s*"
+        + r"(?P<allfuncs>"
+        + _funcname  # group for all function names
+        + r"(?P<morefuncs>([,]\s+"
+        + _funcnamenext
+        + r")*)"
+        + r")"
+        + r"(?P<trailing>[,\.])?"  # end of "allfuncs"
+        + _description  # Some function lists have a trailing comma (or period)  '\s*'
+    )
+
+    # Empty <DESC> elements are replaced with '..'
+    empty_description = ".."
+
+    def _parse_see_also(self, content):
+        """
+        func_name : Descriptive text
+            continued text
+        another_func_name : Descriptive text
+        func_name1, func_name2, :meth:`func_name`, func_name3
+
+        """
+
+        content = dedent_lines(content)
+
+        items = []
+
+        def parse_item_name(text):
+            """Match ':role:`name`' or 'name'."""
+            m = self._func_rgx.match(text)
+            if not m:
+                self._error_location(f"Error parsing See Also entry {line!r}")
+            role = m.group("role")
+            name = m.group("name") if role else m.group("name2")
+            return name, role, m.end()
+
+        rest = []
+        for line in content:
+            if not line.strip():
+                continue
+
+            line_match = self._line_rgx.match(line)
+            description = None
+            if line_match:
+                description = line_match.group("desc")
+                if line_match.group("trailing") and description:
+                    self._error_location(
+                        "Unexpected comma or period after function list at index %d of "
+                        'line "%s"' % (line_match.end("trailing"), line),
+                        error=False,
+                    )
+            if not description and line.startswith(" "):
+                rest.append(line.strip())
+            elif line_match:
+                funcs = []
+                text = line_match.group("allfuncs")
+                while True:
+                    if not text.strip():
+                        break
+                    name, role, match_end = parse_item_name(text)
+                    funcs.append((name, role))
+                    text = text[match_end:].strip()
+                    if text and text[0] == ",":
+                        text = text[1:].strip()
+                rest = list(filter(None, [description]))
+                items.append((funcs, rest))
+            else:
+                self._error_location(f"Error parsing See Also entry {line!r}")
+        return items
+
+    def _parse_index(self, section, content):
+        """
+        .. index:: default
+           :refguide: something, else, and more
+
+        """
+
+        def strip_each_in(lst):
+            return [s.strip() for s in lst]
+
+        out = {}
+        section = section.split("::")
+        if len(section) > 1:
+            out["default"] = strip_each_in(section[1].split(","))[0]
+        for line in content:
+            line = line.split(":")
+            if len(line) > 2:
+                out[line[1]] = strip_each_in(line[2].split(","))
+        return out
+
+    def _parse_summary(self):
+        """Grab signature (if given) and summary"""
+        if self._is_at_section():
+            return
+
+        # If several signatures present, take the last one
+        while True:
+            summary = self._doc.read_to_next_empty_line()
+            summary_str = " ".join([s.strip() for s in summary]).strip()
+            compiled = re.compile(r"^([\w., ]+=)?\s*[\w\.]+\(.*\)$")
+            if compiled.match(summary_str):
+                self["Signature"] = summary_str
+                if not self._is_at_section():
+                    continue
+            break
+
+        if summary is not None:
+            self["Summary"] = summary
+
+        if not self._is_at_section():
+            self["Extended Summary"] = self._read_to_next_section()
+
+    def _parse(self):
+        self._doc.reset()
+        self._parse_summary()
+
+        sections = list(self._read_sections())
+        section_names = {section for section, content in sections}
+
+        has_yields = "Yields" in section_names
+        # We could do more tests, but we are not. Arbitrarily.
+        if not has_yields and "Receives" in section_names:
+            msg = "Docstring contains a Receives section but not Yields."
+            raise ValueError(msg)
+
+        for section, content in sections:
+            if not section.startswith(".."):
+                section = (s.capitalize() for s in section.split(" "))
+                section = " ".join(section)
+                if self.get(section):
+                    self._error_location(
+                        "The section %s appears twice in  %s"
+                        % (section, "\n".join(self._doc._str))
+                    )
+
+            if section in ("Parameters", "Other Parameters", "Attributes", "Methods"):
+                self[section] = self._parse_param_list(content)
+            elif section in ("Returns", "Yields", "Raises", "Warns", "Receives"):
+                self[section] = self._parse_param_list(
+                    content, single_element_is_type=True
+                )
+            elif section.startswith(".. index::"):
+                self["index"] = self._parse_index(section, content)
+            elif section == "See Also":
+                self["See Also"] = self._parse_see_also(content)
+            else:
+                self[section] = content
+
+    @property
+    def _obj(self):
+        if hasattr(self, "_cls"):
+            return self._cls
+        elif hasattr(self, "_f"):
+            return self._f
+        return None
+
+    def _error_location(self, msg, error=True):
+        if self._obj is not None:
+            # we know where the docs came from:
+            try:
+                filename = inspect.getsourcefile(self._obj)
+            except TypeError:
+                filename = None
+            # Make UserWarning more descriptive via object introspection.
+            # Skip if introspection fails
+            name = getattr(self._obj, "__name__", None)
+            if name is None:
+                name = getattr(getattr(self._obj, "__class__", None), "__name__", None)
+            if name is not None:
+                msg += f" in the docstring of {name}"
+            msg += f" in {filename}." if filename else ""
+        if error:
+            raise ValueError(msg)
+        else:
+            warn(msg, stacklevel=3)
+
+    # string conversion routines
+
+    def _str_header(self, name, symbol="-"):
+        return [name, len(name) * symbol]
+
+    def _str_indent(self, doc, indent=4):
+        return [" " * indent + line for line in doc]
+
+    def _str_signature(self):
+        if self["Signature"]:
+            return [self["Signature"].replace("*", r"\*")] + [""]
+        return [""]
+
+    def _str_summary(self):
+        if self["Summary"]:
+            return self["Summary"] + [""]
+        return []
+
+    def _str_extended_summary(self):
+        if self["Extended Summary"]:
+            return self["Extended Summary"] + [""]
+        return []
+
+    def _str_param_list(self, name):
+        out = []
+        if self[name]:
+            out += self._str_header(name)
+            for param in self[name]:
+                parts = []
+                if param.name:
+                    parts.append(param.name)
+                if param.type:
+                    parts.append(param.type)
+                out += [" : ".join(parts)]
+                if param.desc and "".join(param.desc).strip():
+                    out += self._str_indent(param.desc)
+            out += [""]
+        return out
+
+    def _str_section(self, name):
+        out = []
+        if self[name]:
+            out += self._str_header(name)
+            out += self[name]
+            out += [""]
+        return out
+
+    def _str_see_also(self, func_role):
+        if not self["See Also"]:
+            return []
+        out = []
+        out += self._str_header("See Also")
+        out += [""]
+        last_had_desc = True
+        for funcs, desc in self["See Also"]:
+            assert isinstance(funcs, list)
+            links = []
+            for func, role in funcs:
+                if role:
+                    link = f":{role}:`{func}`"
+                elif func_role:
+                    link = f":{func_role}:`{func}`"
+                else:
+                    link = f"`{func}`_"
+                links.append(link)
+            link = ", ".join(links)
+            out += [link]
+            if desc:
+                out += self._str_indent([" ".join(desc)])
+                last_had_desc = True
+            else:
+                last_had_desc = False
+                out += self._str_indent([self.empty_description])
+
+        if last_had_desc:
+            out += [""]
+        out += [""]
+        return out
+
+    def _str_index(self):
+        idx = self["index"]
+        out = []
+        output_index = False
+        default_index = idx.get("default", "")
+        if default_index:
+            output_index = True
+        out += [f".. index:: {default_index}"]
+        for section, references in idx.items():
+            if section == "default":
+                continue
+            output_index = True
+            out += [f"   :{section}: {', '.join(references)}"]
+        if output_index:
+            return out
+        return ""
+
+    def __str__(self, func_role=""):
+        out = []
+        out += self._str_signature()
+        out += self._str_summary()
+        out += self._str_extended_summary()
+        out += self._str_param_list("Parameters")
+        for param_list in ("Attributes", "Methods"):
+            out += self._str_param_list(param_list)
+        for param_list in (
+            "Returns",
+            "Yields",
+            "Receives",
+            "Other Parameters",
+            "Raises",
+            "Warns",
+        ):
+            out += self._str_param_list(param_list)
+        out += self._str_section("Warnings")
+        out += self._str_see_also(func_role)
+        for s in ("Notes", "References", "Examples"):
+            out += self._str_section(s)
+        out += self._str_index()
+        return "\n".join(out)
+
+
+def dedent_lines(lines):
+    """Deindent a list of lines maximally"""
+    return textwrap.dedent("\n".join(lines)).split("\n")
+
+
+class FunctionDoc(NumpyDocString):
+    def __init__(self, func, role="func", doc=None, config=None):
+        self._f = func
+        self._role = role  # e.g. "func" or "meth"
+
+        if doc is None:
+            if func is None:
+                raise ValueError("No function or docstring given")
+            doc = inspect.getdoc(func) or ""
+        if config is None:
+            config = {}
+        NumpyDocString.__init__(self, doc, config)
+
+    def get_func(self):
+        func_name = getattr(self._f, "__name__", self.__class__.__name__)
+        if inspect.isclass(self._f):
+            func = getattr(self._f, "__call__", self._f.__init__)
+        else:
+            func = self._f
+        return func, func_name
+
+    def __str__(self):
+        out = ""
+
+        func, func_name = self.get_func()
+
+        roles = {"func": "function", "meth": "method"}
+
+        if self._role:
+            if self._role not in roles:
+                print(f"Warning: invalid role {self._role}")
+            out += f".. {roles.get(self._role, '')}:: {func_name}\n    \n\n"
+
+        out += super().__str__(func_role=self._role)
+        return out
+
+
+class ObjDoc(NumpyDocString):
+    def __init__(self, obj, doc=None, config=None):
+        self._f = obj
+        if config is None:
+            config = {}
+        NumpyDocString.__init__(self, doc, config=config)
+
+
+class ClassDoc(NumpyDocString):
+    extra_public_methods = ["__call__"]
+
+    def __init__(self, cls, doc=None, modulename="", func_doc=FunctionDoc, config=None):
+        if not inspect.isclass(cls) and cls is not None:
+            raise ValueError(f"Expected a class or None, but got {cls!r}")
+        self._cls = cls
+
+        if "sphinx" in sys.modules:
+            from sphinx.ext.autodoc import ALL
+        else:
+            ALL = object()
+
+        if config is None:
+            config = {}
+        self.show_inherited_members = config.get("show_inherited_class_members", True)
+
+        if modulename and not modulename.endswith("."):
+            modulename += "."
+        self._mod = modulename
+
+        if doc is None:
+            if cls is None:
+                raise ValueError("No class or documentation string given")
+            doc = pydoc.getdoc(cls)
+
+        NumpyDocString.__init__(self, doc)
+
+        _members = config.get("members", [])
+        if _members is ALL:
+            _members = None
+        _exclude = config.get("exclude-members", [])
+
+        if config.get("show_class_members", True) and _exclude is not ALL:
+
+            def splitlines_x(s):
+                if not s:
+                    return []
+                else:
+                    return s.splitlines()
+
+            for field, items in [
+                ("Methods", self.methods),
+                ("Attributes", self.properties),
+            ]:
+                if not self[field]:
+                    doc_list = []
+                    for name in sorted(items):
+                        if name in _exclude or (_members and name not in _members):
+                            continue
+                        try:
+                            doc_item = pydoc.getdoc(getattr(self._cls, name))
+                            doc_list.append(Parameter(name, "", splitlines_x(doc_item)))
+                        except AttributeError:
+                            pass  # method doesn't exist
+                    self[field] = doc_list
+
+    @property
+    def methods(self):
+        if self._cls is None:
+            return []
+        return [
+            name
+            for name, func in inspect.getmembers(self._cls)
+            if (
+                (not name.startswith("_") or name in self.extra_public_methods)
+                and isinstance(func, Callable)
+                and self._is_show_member(name)
+            )
+        ]
+
+    @property
+    def properties(self):
+        if self._cls is None:
+            return []
+        return [
+            name
+            for name, func in inspect.getmembers(self._cls)
+            if (
+                not name.startswith("_")
+                and not self._should_skip_member(name, self._cls)
+                and (
+                    func is None
+                    or isinstance(func, (property, cached_property))
+                    or inspect.isdatadescriptor(func)
+                )
+                and self._is_show_member(name)
+            )
+        ]
+
+    @staticmethod
+    def _should_skip_member(name, klass):
+        return (
+            # Namedtuples should skip everything in their ._fields as the
+            # docstrings for each of the members is: "Alias for field number X"
+            issubclass(klass, tuple)
+            and hasattr(klass, "_asdict")
+            and hasattr(klass, "_fields")
+            and name in klass._fields
+        )
+
+    def _is_show_member(self, name):
+        return (
+            # show all class members
+            self.show_inherited_members
+            # or class member is not inherited
+            or name in self._cls.__dict__
+        )
+
+
+def get_doc_object(
+    obj,
+    what=None,
+    doc=None,
+    config=None,
+    class_doc=ClassDoc,
+    func_doc=FunctionDoc,
+    obj_doc=ObjDoc,
+):
+    if what is None:
+        if inspect.isclass(obj):
+            what = "class"
+        elif inspect.ismodule(obj):
+            what = "module"
+        elif isinstance(obj, Callable):
+            what = "function"
+        else:
+            what = "object"
+    if config is None:
+        config = {}
+
+    if what == "class":
+        return class_doc(obj, func_doc=func_doc, doc=doc, config=config)
+    elif what in ("function", "method"):
+        return func_doc(obj, doc=doc, config=config)
+    else:
+        if doc is None:
+            doc = pydoc.getdoc(obj)
+        return obj_doc(obj, doc, config=config)

--- a/src/graph2mat/core/data/__init__.py
+++ b/src/graph2mat/core/data/__init__.py
@@ -26,5 +26,6 @@ from .basis import PointBasis
 from .configuration import BasisConfiguration, OrbitalConfiguration
 from .metrics import OrbitalMatrixMetric
 from . import metrics
-from .processing import MatrixDataProcessor, BasisMatrixData
+from .processing import MatrixDataProcessor, BasisMatrixData, BasisMatrixDataBase
 from .table import BasisTableWithEdges, AtomicTableWithEdges
+from .formats import Formats, conversions, ConversionManager

--- a/src/graph2mat/core/data/formats.py
+++ b/src/graph2mat/core/data/formats.py
@@ -1,0 +1,685 @@
+"""Module defining formats and conversion management.
+
+Handling sparse matrices for associated 3D point clouds with basis functions is sometimes
+not straightforward. For each different task (e.g. training a ML model, computing a property...)
+there might be some data format that is more convenient. To the user (and the developer), converting
+from any format to any other target format can be a pain. In `graph2mat`, we try to centralize
+this task by:
+
+- Having a class, `Formats`, that contains all the formats that we support.
+- Having a class that manages the conversions between these formats: `ConversionManager``.
+
+An instance of `ConversionManager` is available at ``graph2mat.conversions``.
+"""
+import inspect
+from typing import Callable, Any, overload, Optional
+
+from collections import ChainMap
+import functools
+
+import numpy as np
+import scipy
+import sisl
+
+from .._docstrings import FunctionDoc
+
+
+# --------------------------------------
+#    REGISTER OF KNOWN FORMATS
+# --------------------------------------
+# We define all formats here, even if they are formats specific to bindings.
+# This is to make it more clear what formats are available, otherwise it
+# gets too messy with formats being defined all over the place.
+class Formats:
+    """Class holding all known formats.
+
+    These are referenced by the conversion manager to understand what a function
+    converts from and to.
+    """
+
+    #: Dictionary mapping aliases to formats.
+    _aliases: dict[Any, str] = {}
+    #: Dictionary mapping formats to aliases.
+    _format_to_aliases: dict[str, list[Any]] = {}
+
+    #: The format for a row block dictionary.
+    BLOCK_DICT = "block_dict"
+    #: The format for graph2mat's ``BasisMatrix``.
+    BASISMATRIX = "basismatrix"
+
+    #: The format for graph2mat's ``BasisConfiguration`` class.
+    BASISCONFIGURATION = "basisconfiguration"
+    #: The format for graph2mat's ``OrbitalConfiguration`` class.
+    ORBITALCONFIGURATION = "orbitalconfiguration"
+
+    #: Pseudoformat, arrays for edge and node values, without a container.
+    NODESEDGES = "nodesedges"
+    #: Pseudoformat, same as ``NODESEDGES`` but in torch tensors.
+    TORCH_NODESEDGES = "torch_nodesedges"
+
+    #: Numpy array
+    NUMPY = "numpy"
+
+    #: Scipy sparse COO matrix/array
+    SCIPY_COO = "scipy_coo"
+    #: Scipy sparse CSR matrix/array
+    SCIPY_CSR = "scipy_csr"
+
+    #: Sisl ``SparseOrbital`` class
+    SISL = "sisl"
+    #: Sisl ``Hamiltonian`` class
+    SISL_H = "sisl_H"
+    #: Sisl ``DensityMatrix`` class
+    SISL_DM = "sisl_DM"
+    #: Sisl ``EnergyDensityMatrix`` class
+    SISL_EDM = "sisl_EDM"
+    #: Sisl ``Geometry`` class, doesn't contain matrix information.
+    SISL_GEOMETRY = "sisl_geometry"
+    #: Pseudoformat, path to a file from which sisl can read a matrix's data.
+    SISL_SILE = "sisl_sile"
+
+    #: The format for graph2mat's ``BasisMatrixData`` class
+    BASISMATRIXDATA = "basismatrixdata"
+    #: The format for graph2mat's ``TorchBasisMatrixData`` class.
+    TORCH_BASISMATRIXDATA = "torch_basismatrixdata"
+
+    #: Torch tensor
+    TORCH = "torch"
+    #: Torch sparse COO tensor
+    TORCH_COO = "torch_coo"
+    #: Torch sparse CSR tensor
+    TORCH_CSR = "torch_csr"
+
+    #: List of all pseudoformats. This is useful for the ConversionManager for
+    #: example, as conversion functions don't have a single argument to pass the
+    #: data to convert. A function to convert from a pseudo format accepts the
+    #: data as multiple arguments.
+    _pseudo_formats: list[str] = [NODESEDGES, TORCH_NODESEDGES]
+
+    @classmethod
+    def add_alias(cls, fmt: str, *aliases: Any):
+        """Add an alias for a format.
+
+        Parameters
+        ----------
+        fmt :
+            The format name.
+        aliases :
+            The aliases that will be associated with the format.
+            They don't need to be strings, they can be e.g. a
+            class.
+        """
+        for alias in aliases:
+            cls._aliases[alias] = fmt
+
+        if fmt not in cls._format_to_aliases:
+            cls._format_to_aliases[fmt] = []
+
+        cls._format_to_aliases[fmt].extend(aliases)
+
+    @classmethod
+    def string_to_attr_name(cls, format_string: str) -> str:
+        """Get the attribute name that corresponds to a given format string.
+
+        This function is quite slow.
+
+        Parameters
+        ----------
+        format_string :
+            The format string.
+
+        Returns
+        -------
+        attr_name :
+            The attribute name.
+        """
+        for attr in dir(cls):
+            if getattr(cls, attr) == format_string:
+                return attr
+        else:
+            raise ValueError(f"Format '{format_string}' not found")
+
+
+# --------------------------------------
+#    MAPPING PYTHON TYPES TO FORMATS
+# --------------------------------------
+# Numpy types
+Formats.add_alias(Formats.NUMPY, np.ndarray)
+# Scipy types
+Formats.add_alias(Formats.SCIPY_COO, scipy.sparse.coo_matrix)
+Formats.add_alias(Formats.SCIPY_COO, scipy.sparse.coo_array)
+Formats.add_alias(Formats.SCIPY_CSR, scipy.sparse.csr_matrix)
+Formats.add_alias(Formats.SCIPY_CSR, scipy.sparse.csr_array)
+# Sisl types
+Formats.add_alias(Formats.SISL, sisl.SparseOrbital)
+Formats.add_alias(Formats.SISL_H, sisl.Hamiltonian)
+Formats.add_alias(Formats.SISL_DM, sisl.DensityMatrix)
+Formats.add_alias(Formats.SISL_EDM, sisl.EnergyDensityMatrix)
+Formats.add_alias(Formats.SISL_GEOMETRY, sisl.Geometry)
+
+# --------------------------------------
+#      MANAGEMENT OF CONVERSIONS
+# --------------------------------------
+
+
+class ConversionManager:
+    """Manages the conversions between formats.
+
+    This class centralizes the handling of conversions between formats.
+    It uses the formats defined in the ``Formats`` class.
+
+    Examples
+    --------
+    The conversion manager needs to be instantiated in order to be used:
+
+    .. code-block:: python
+
+        conversions = ConversionManager()
+
+    Notice that by doing that, you get an empty conversion manager (with no
+    implemented conversions). ``graph2mat`` already **provides an instantiated
+    conversion manager with all the implemented conversions**. It can be imported
+    like:
+
+    .. code-block:: python
+
+        from graph2mat import conversions
+
+    Then, converters can be registered using the ``register_converter`` method:
+
+    .. code-block:: python
+
+        def my_converter(data: np.ndarray) -> scipy.sparse.coo_matrix:
+            ...
+
+        conversions.register_converter(Formats.NUMPY, Formats.SCIPY_COO, my_converter)
+
+    Or using the ``converter`` decorator:
+
+    .. code-block:: python
+
+        @conversions.converter(Formats.NUMPY, Formats.SCIPY_COO)
+        def my_converter(data: np.ndarray) -> scipy.sparse.coo_matrix:
+            ...
+
+    The registered converters can be retrieved using the ``get_converter`` method:
+
+    .. code-block:: python
+
+        converter = conversions.get_converter(Formats.NUMPY, Formats.SCIPY_COO)
+
+        # Matrix as a numpy array
+        array = np.random.rand(10, 10)
+        # Use the converter to get the matrix as a scipy sparse COO matrix
+        sparse_coo = converter(array)
+
+    They converters are also registered as attributes of the conversion manager,
+    with the names being `<source>_to_<target>`. For example, to get the numpy
+    to scipy COO converter, one can also do:
+
+    .. code-block:: python
+
+        converter = conversions.numpy_to_scipy_coo
+
+    .. note::
+
+        When writing code that should be future-proof (e.g. inside a package), we
+        recommend using ``get_converter`` with the formats retreived from ``Formats``.
+        In the very unlikely event that some format name changes, the error raised
+        will be more informative.
+
+    See Also
+    --------
+    Formats
+        The class that defines all formats.
+    """
+
+    #: Dictionary holding all explicitly registered converters.
+    #: Keys are tuples (source, target) and values are the converter functions.
+    _registered_converters: dict[tuple[str, str], Callable] = {}
+
+    #: Dictionary holding all automatically generated converters.
+    #: Keys are tuples (source, target) and values are the converter functions.
+    _autodef_converters: dict[tuple[str, str], Callable] = {}
+
+    #: ChainMap of all converters, with the registered converters taking precedence.
+    _converters: ChainMap[tuple[str, str], Callable]
+
+    #: List of callbacks that are called every time a new converter is registered.
+    _callbacks: list[Callable[[str, str, Callable, "ConversionManager"], Any]] = []
+
+    def __init__(self):
+        self._registered_converters = {}
+        self._autodef_converters = {}
+        self._converters = ChainMap(
+            self._registered_converters, self._autodef_converters
+        )
+        self._callbacks = []
+
+    def get_converter(self, source: str, target: str) -> Callable:
+        """Get a converter function between two formats.
+
+        It raises a ``KeyError`` if no converter is found.
+
+        Parameters
+        ----------
+        source :
+            The source format.
+        target :
+            The target format.
+
+        Returns
+        -------
+        converter :
+            The converter function for the given formats.
+        """
+        try:
+            return self._converters[(source, target)]
+        except KeyError:
+            raise KeyError(f"No converter found from '{source}' to '{target}'")
+
+    def has_converter(self, source: str, target: str) -> bool:
+        """Check if a converter exists between two formats.
+
+        Parameters
+        ----------
+        source :
+            The source format.
+        target :
+            The target format.
+        """
+        return (source, target) in self._converters
+
+    def register_converter(
+        self,
+        source: str,
+        target: str,
+        converter: Callable,
+        exists_ok: bool = False,
+        autodef: bool = False,
+    ):
+        """Register a converter function between two formats.
+
+        Parameters
+        ----------
+        source :
+            The source format.
+        target :
+            The target format.
+        converter :
+            The function that converts from source to target.
+        exists_ok :
+            If ``False``, raises a ``KeyError`` error if a converter
+            from ``source`` to ``target`` already exists.
+        autodef :
+            Whether this is an automatically generated converter.
+            Only set to ``True`` by internal calls, should not be set by the user.
+        """
+
+        if not exists_ok and (source, target) in self._registered_converters:
+            raise KeyError(f"Converter from '{source}' to '{target}' already exists")
+
+        if autodef:
+            self._autodef_converters[(source, target)] = converter
+        else:
+            # Add the converter
+            self._converters[(source, target)] = converter
+
+        setattr(self, f"{source}_to_{target}", converter)
+
+        if autodef:
+            return
+
+        # If the converter only has one argument, then we can try to extend
+        # the list of converters by chaining them.
+        # E.g. the registered converter is from A to B with a single argument,
+        # and there is a registered converter from B to C. Then we can automatically
+        # register a converter from A to C that does A -> B -> C, because it doesn't
+        # require any additional information.
+        try:
+            sig = inspect.signature(converter)
+            if len(sig.parameters) == 1:
+
+                def _auto_converter_callback(
+                    new_source, new_target, new_converter, manager
+                ):
+                    if new_target == source:
+                        # Trigger an expansion to the right:
+                        # source -> target [-> new_target]
+                        if new_source == target or manager.has_converter(
+                            new_source, target
+                        ):
+                            return
+
+                        manager.register_expanded_converter(
+                            new_source, new_target, source, target, converter
+                        )
+
+                    if target == new_source:
+                        # Trigger and expansion to the left:
+                        # [new_source ->] source -> target
+                        if source == new_target or manager.has_converter(
+                            source, new_target
+                        ):
+                            return
+
+                        if new_source in Formats._pseudo_formats:
+                            return
+
+                        manager.register_expanded_converter(
+                            new_source, new_target, source, target, converter
+                        )
+
+                self.add_callback(_auto_converter_callback, retroactive=True)
+        except:
+            pass
+
+        for callback in self._callbacks:
+            callback(source, target, converter, self)
+
+    def register_expanded_converter(
+        self,
+        old_source: str,
+        old_target: str,
+        expansion_source: str,
+        expansion_target: str,
+        expansion: Callable,
+    ):
+        """Registers a converter that is an expansion of an existing one.
+
+        This function takes care of modifying the signature, docstring etc... so that
+        the user still sees some helpful information when inspecting the converter
+        e.g. in a Jupyter notebook or in the documentation.
+
+        The function will automatically detect whether the original converter
+        is to be expanded to the left or to the right, and will create a new
+        converter that chains the original one with the expansion.
+
+        Parameters
+        ----------
+        old_source
+            The source format of the original converter.
+        old_target
+            The target format of the original converter.
+        expansion_source
+            The source format of the expansion.
+        expansion_target
+            The target format of the expansion.
+        expansion
+            The function that expands the original converter.
+        """
+        # Information about the original converter
+        old_converter = self.get_converter(old_source, old_target)
+        old_signature = inspect.signature(old_converter)
+        old_annotations = getattr(old_converter, "__annotations__", {})
+        old_fdoc = FunctionDoc(old_converter)
+        old_path = getattr(old_converter, "_converter_path", (old_source, old_target))
+        explicit_converter = getattr(
+            old_converter, "_explicit_converter", (old_source, old_target)
+        )
+        # Information about the expansion
+        expansion_signature = inspect.signature(expansion)
+        expansion_fdoc = FunctionDoc(expansion)
+        expansion_annotations = getattr(expansion, "__annotations__", {})
+
+        if expansion_target == old_source:
+            # Converter expanded "to the left"
+            path = (expansion_source, *old_path)
+
+            # The first argument is getting replaced to accept the input of
+            # the expansion instead. Here we do all the work to erase any
+            # trace of the original first argument, and document the new
+            # first argument instead. The name of the new first argument
+            # might already be taken by another parameter, in which case
+            # we rename the original first argument to "first_arg".
+            first_param = list(expansion_signature.parameters.values())[0]
+            orig_first_param_name = first_param.name
+            old_params = list(old_signature.parameters.values())
+
+            if first_param.name in old_signature.parameters:
+                first_param = first_param.replace(name="first_arg")
+
+            signature = old_signature.replace(
+                parameters=[first_param, *old_params[1:]],
+            )
+
+            new_params_doc = list(
+                filter(
+                    lambda p: p.name.replace(":", "") != old_params[0].name,
+                    old_fdoc["Parameters"],
+                )
+            )
+
+            for p in expansion_fdoc["Parameters"]:
+                if p.name.replace(":", "").strip() == orig_first_param_name:
+                    p = p.__class__(name=first_param.name, type=p.type, desc=p.desc)
+                    new_params_doc.insert(0, p)
+                    break
+
+            old_fdoc["Parameters"] = new_params_doc
+            annotations = {
+                **old_annotations,
+                first_param.name: expansion_annotations.get(orig_first_param_name),
+            }
+
+            # Define the chained converter
+            def _composite(*args, **kwargs):
+                # Find the first argument, which will be passed to the expansion
+                if len(args) > 0:
+                    first_arg, *args = args
+                else:
+                    first_arg = kwargs.pop(first_param.name)
+                # Call the converter with the first argument converted
+                return old_converter(expansion(first_arg), *args, **kwargs)
+
+        elif expansion_source == old_target:
+            # Converter expanded "to the right"
+            path = (*old_path, expansion_target)
+
+            def _composite(*args, **kwargs):
+                return expansion(old_converter(*args, **kwargs))
+
+            # This case is simpler, we just need to modify the return information
+            signature = old_signature.replace(
+                return_annotation=expansion_signature.return_annotation
+            )
+            old_fdoc["Returns"] = expansion_fdoc["Returns"]
+            annotations = {**old_annotations, "return": expansion_annotations["return"]}
+        else:
+            raise ValueError(
+                f"Can't expand converter '{old_source}'->'{old_target}' with expansion '{expansion_source}' -> '{expansion_target}'"
+            )
+
+        # Make the function look nice to the outside world
+        _composite.__name__ = f"{path[0]}_to_{path[-1]}"
+        _composite.__qualname__ = f"{path[0]}_to_{path[-1]}"
+        _composite.__signature__ = signature
+        _composite.__annotations__ = annotations
+        _composite._converter_path = path
+        _composite._explicit_converter = explicit_converter
+
+        prev_format = path[0]
+        full_path_string = ""
+        for fmt in path[1:]:
+            if full_path_string.endswith("] -> "):
+                continue
+
+            if prev_format == explicit_converter[0] and fmt == explicit_converter[-1]:
+                full_path_string += f" [ ``{prev_format}`` -> ``{fmt}`` ] -> "
+            else:
+                full_path_string += f" ``{prev_format}`` -> "
+
+            prev_format = fmt
+        if full_path_string.endswith(f"``{fmt}`` ] -> "):
+            full_path_string = full_path_string.removesuffix(" -> ")
+        else:
+            full_path_string += f"``{fmt}``"
+
+        old_fdoc["Summary"] = [f"Conversion from '{path[0]}' to '{path[-1]}'."]
+        old_fdoc["Extended Summary"] = [
+            "\n\nThis function has been defined automatically."
+            "\n\nThe full path of the conversion is (original converter in square brackets):\n\n"
+            + full_path_string,
+        ]
+
+        old_fdoc["See Also"] = [
+            (
+                [(f"{explicit_converter[0]}_to_{explicit_converter[-1]}", None)],
+                ["The original converter that has been expanded to create this one."],
+            ),
+        ]
+
+        for k in old_fdoc:
+            if k not in [
+                "Summary",
+                "Extended Summary",
+                "Parameters",
+                "Returns",
+                "See Also",
+            ]:
+                old_fdoc[k] = old_fdoc[k].__class__()
+
+        docstring = str(old_fdoc)
+        _composite.__doc__ = docstring[docstring.find("\n") :].lstrip()
+
+        # And register it
+        self.register_converter(path[0], path[-1], _composite, autodef=True)
+
+    @overload
+    def converter(
+        self, source: str, target: str, exists_ok: bool = False
+    ) -> Callable[[Callable], Callable]:
+        ...
+
+    @overload
+    def converter(self, converter: Callable, exists_ok: bool = False) -> Callable:
+        ...
+
+    def converter(self, *args, exists_ok: bool = False):
+        """Decorator to register a converter while defining a function.
+
+        Examples
+        --------
+        There are two ways to use this decorator:
+
+        1. As a decorator with two arguments:
+
+        .. code-block:: python
+
+            @converter("source_format", "target_format")
+            def my_converter(...):
+                ...
+
+        Where ``source_format`` and ``target_format`` are strings representing
+        the input and output formats of the converter.
+
+        2. As a no argument decorator:
+
+        .. code-block:: python
+
+            @converter
+            def my_converter(data: np.ndarray) -> scipy.sparse.coo_matrix:
+                ...
+
+        In which case the source and target formats are inferred
+        from the function signature.
+
+        """
+        if len(args) == 1:
+            # This is the case when the decorator is used without arguments.
+            # Then the first argument is the function to be decorated.
+            converter = args[0]
+
+            # Find out source and target from the function signature
+            # if the function only has one argument
+            sig = inspect.signature(converter)
+            if len(sig.parameters) != 1:
+                raise ValueError(
+                    "Can't guess source for converter with more than one argument, please provide them explicitly"
+                )
+            _, param = next(iter(sig.parameters.items()))
+            source = param.annotation
+            target = sig.return_annotation
+
+            # Try to get the format that corresponds to each of the types.
+            try:
+                source = Formats._aliases[source]
+            except KeyError:
+                raise ValueError(
+                    f"Could not guess format from argument annotation '{source}'"
+                )
+
+            try:
+                target = Formats._aliases[target]
+            except KeyError:
+                raise ValueError(
+                    f"Could not guess format from return annotation '{target}'"
+                )
+
+            self.register_converter(source, target, converter, exists_ok=exists_ok)
+            return converter
+        else:
+            # This is the case when the decorator is used with two arguments.
+            source, target = args
+
+            def wrapper(converter):
+                self.register_converter(source, target, converter, exists_ok=exists_ok)
+                return converter
+
+        return wrapper
+
+    def add_callback(
+        self,
+        callback: Callable[[str, str, Callable, "ConversionManager"], Any],
+        retroactive: bool = False,
+    ):
+        """Add a function that will be called every time a new converter is registered.
+
+        Parameters
+        ----------
+        callback :
+            The callback function. It will receive the source format, target format,
+            the converter function being registered and the ConversionManager instance.
+        retroactive : bool
+            If True, the callback will be called for all converters that have been
+            previously registered.
+        """
+        self._callbacks.append(callback)
+        if retroactive:
+            items = list(self._converters.items())
+            for (source, target), converter in items:
+                callback(source, target, converter, self)
+
+    def _repr_html_(self) -> str:
+        table = "<table><tbody>"
+        table += f"<tr><th>Source</th><th>Target</th></tr>"
+
+        for source, target in sorted(self._converters):
+            table += f"<tr><td>{source}</td><td>{target}</td></tr>"
+
+        table += "</tbody></table>"
+
+        return table
+
+    def get_available_targets(self, source: str) -> list[str]:
+        """For a given format, return all formats it can be converted to.
+
+        Parameters
+        ----------
+        source :
+            The source format.
+        """
+        return [target for (s, target) in self._converters if s == source]
+
+    def get_available_sources(self, target: str) -> list[str]:
+        """For a given format, return all formats it can be converted from.
+
+        Parameters
+        ----------
+        target :
+            The target format
+        """
+        return [source for (source, t) in self._converters if t == target]
+
+
+conversions = ConversionManager()

--- a/src/graph2mat/core/data/metrics.py
+++ b/src/graph2mat/core/data/metrics.py
@@ -13,6 +13,7 @@ from copy import copy
 from typing import Any, Tuple, Dict, Type, Callable, Union
 import numpy as np
 
+from .formats import Formats
 from .processing import MatrixDataProcessor
 
 __all__ = [
@@ -791,7 +792,7 @@ def normalized_density_error(
     This is the error of the density in real space divided by the number of electrons.
     """
     import sisl
-    from graph2mat import BasisMatrixData
+    from graph2mat import BasisMatrixDataBase
 
     # Get the errors in the density matrix. Make sure that NaNs are set to 0, which
     # basically means that they will have no influence on the error.
@@ -800,13 +801,13 @@ def normalized_density_error(
     )
     errors[1][_isnan(errors[1])] = 0
 
-    if isinstance(batch, BasisMatrixData):
+    if isinstance(batch, BasisMatrixDataBase):
         # We haven't really received a batch, but just a single structure.
         # Do as if we received a batch of size 1.
         matrix_error = copy(batch)
         matrix_error.point_labels = errors[0]
         matrix_error.edge_labels = errors[1]
-        matrix_errors = [matrix_error.to_sparse_orbital_matrix()]
+        matrix_errors = [matrix_error.convert_to(Formats.SISL_DM)]
     else:
         # Create an iterator that returns the error for each structure in the batch
         # as a sisl DensityMatrix.

--- a/src/graph2mat/tools/lightning/callbacks.py
+++ b/src/graph2mat/tools/lightning/callbacks.py
@@ -26,7 +26,7 @@ from graph2mat.tools.viz import plot_basis_matrix
 
 class MatrixWriter(Callback):
     """Callback to write predicted matrices to disk."""
-    
+
     def __init__(
         self,
         output_file: str,
@@ -34,17 +34,12 @@ class MatrixWriter(Callback):
             "train",
             "val",
             "test",
-            "predict"
+            "predict",
         ],  # I don't know why, but Sequence[str] breaks the lightning CLI
     ):
         super().__init__()
 
-        splits = [
-            "train",
-            "val",
-            "test",
-            "predict"
-        ]
+        splits = ["train", "val", "test", "predict"]
 
         if splits in ["train", "val", "test", "predict"]:
             splits = [splits]
@@ -74,7 +69,7 @@ class MatrixWriter(Callback):
         # Loop through structures in the batch
         for matrix_data in matrix_iter:
             sparse_orbital_matrix = matrix_data.to_sparse_orbital_matrix()
-            
+
             # Get the path from which this structure was read.
             path = matrix_data.metadata["path"]
             out_file = Path(self.output_file.replace("$name$", path.parent.name))
@@ -86,7 +81,6 @@ class MatrixWriter(Callback):
 
             # And write the matrix to it.
             sparse_orbital_matrix.write(out_file)
-
 
     def on_train_batch_end(
         self, trainer, pl_module, outputs, batch, batch_idx, dataloader_idx=None
@@ -111,7 +105,7 @@ class MatrixWriter(Callback):
             self._on_batch_end(
                 "test", trainer, pl_module, outputs, batch, batch_idx, dataloader_idx
             )
-    
+
     def on_predict_batch_end(
         self, trainer, pl_module, outputs, batch, batch_idx, dataloader_idx=None
     ):
@@ -119,7 +113,6 @@ class MatrixWriter(Callback):
             self._on_batch_end(
                 "predict", trainer, pl_module, outputs, batch, batch_idx, dataloader_idx
             )
-
 
 
 class SamplewiseMetricsLogger(Callback):
@@ -410,7 +403,7 @@ class PlotMatrixError(Callback):
             geometry = sisl.Geometry(
                 self.positions,
                 atoms=[basis_table.atoms[at_type] for at_type in self.point_types],
-                sc=self.cell,
+                lattice=self.cell,
             )
 
             geometry.set_nsc(self.nsc)


### PR DESCRIPTION
Essentially, this centralizes all the handling of the formats so that supporting conversion from everything to everything becomes more manageable.

The initial trigger for this change was the need to support outputing the matrices in torch format and keeping the gradients through the process.

The main user visible change is that now `processor.matrix_from_data` has a new `out_format` argument where you can ask for the output to be in any supported format (including `torch_coo/csr` and `torch` for dense tensors).

This still needs a bit of polishing over time, but it is already quite solid. All converters are documented in a page of the documentation.