### PR TITLE
Added the possibility to compute species together within Graph2Mat.

### DIFF
--- a/src/graph2mat/bindings/e3nn/modules/tests/test_e3nngraph2mat.py
+++ b/src/graph2mat/bindings/e3nn/modules/tests/test_e3nngraph2mat.py
@@ -1,0 +1,125 @@
+import pytest
+
+from e3nn import o3
+import numpy as np
+import torch
+
+import copy
+
+from graph2mat import (
+    PointBasis,
+    BasisTableWithEdges,
+    MatrixDataProcessor,
+    BasisConfiguration,
+)
+from graph2mat.bindings.e3nn import E3nnGraph2Mat
+
+from graph2mat import conversions
+
+
+@pytest.fixture(scope="module", params=["point_type", "basis_shape", "max"])
+def basis_grouping(request):
+    return request.param
+
+
+@pytest.fixture(scope="module", params=[True, False])
+def symmetric(request):
+    return request.param
+
+
+def get_rotation_matrix(data, table, alpha, beta, gamma):
+    R_0 = 1
+    R_1 = o3.wigner_D(1, alpha, beta, gamma)
+
+    dim = table.basis_size[data.point_types].sum()
+    big_R = np.zeros((dim, dim))
+
+    for inv_els in (0, 1, 5, 9, 10):
+        big_R[inv_els, inv_els] = R_0
+
+    for start, end in ((2, 5), (6, 9), (11, 14)):
+        big_R[start:end, start:end] = R_1
+
+    return R_1, big_R
+
+
+@pytest.fixture(scope="module", params=[False, True])
+def with_no_basis(request):
+    """Whether the test should include a point with no basis."""
+    return request.param
+
+
+def test_equivariance(basis_grouping, symmetric, with_no_basis):
+    # The basis
+    point_1 = PointBasis("A", R=3, basis="2x0e + 1o", basis_convention="cartesian")
+    point_2 = PointBasis("B", R=3, basis="0e + 1o", basis_convention="cartesian")
+    point_3 = PointBasis("C", R=3, basis="2x0e + 1o", basis_convention="cartesian")
+
+    basis = [point_1, point_2, point_3]
+
+    # Add an extra point with no basis
+    if with_no_basis:
+        point_4 = PointBasis("F", R=3, basis_convention="cartesian")
+        basis.append(point_4)
+
+    # The basis table.
+    table = BasisTableWithEdges(basis)
+    # The data processor.
+    processor = MatrixDataProcessor(
+        basis_table=table, symmetric_matrix=symmetric, sub_point_matrix=False
+    )
+
+    g2m = E3nnGraph2Mat(
+        unique_basis=table,
+        irreps={"node_feats_irreps": o3.Irreps("0e + 1o")},
+        symmetric=symmetric,
+        basis_grouping=basis_grouping,
+    )
+
+    point_types = ["A", "B", "C"]
+    positions = [[1, 1, 1], [2.0, 1, 1], [4.0, 1, 1]]
+    # Add an extra point with no basis. To make sure that things work
+    # in the most general case, we add it in the middle of the list.
+    if with_no_basis:
+        point_types.insert(1, "F")
+        positions.insert(1, [6.0, 1, 1])
+
+    config = BasisConfiguration(
+        point_types=point_types,
+        positions=np.array(positions),
+        basis=basis,
+        cell=np.eye(3) * 100,
+        pbc=(False, False, False),
+    )
+
+    conv = conversions.get_converter("basisconfiguration", "torch_basismatrixdata")
+    data = conv(config, data_processor=processor)
+
+    R1, big_R = get_rotation_matrix(
+        data, table, torch.tensor(0), torch.tensor(0), torch.tensor(90 * np.pi / 180)
+    )
+
+    data_rot = copy.copy(data)
+
+    data_rot.positions = data.positions @ R1.T
+
+    def get_mat(data):
+        node_feats = torch.concatenate(
+            [data.point_types.reshape(-1, 1) + 1, data.positions], axis=1
+        )
+        nodes, edges = g2m(data, node_feats=node_feats)
+
+        return processor.matrix_from_data(
+            data,
+            predictions={"node_labels": nodes, "edge_labels": edges},
+            out_format="numpy",
+        )
+
+    pred = get_mat(data)
+    pred_rot = get_mat(data_rot)
+
+    post_rotated = big_R @ pred @ big_R.T
+
+    max_diff = abs(post_rotated - pred_rot).max()
+
+    assert max_diff < 1e-5, f"Equivariance error is too high: {max_diff:.2e}.\n"

--- a/src/graph2mat/core/data/basis.py
+++ b/src/graph2mat/core/data/basis.py
@@ -277,7 +277,7 @@ class PointBasis:
         for n_shells, l, parity in self.basis:
             for izeta in range(n_shells):
                 for m in range(-l, l + 1):
-                    orb = sisl.AtomicOrbital(n=3, l=l, m=m, zeta=izeta, R=R[i])
+                    orb = sisl.AtomicOrbital(n=3, l=l, m=m, zeta=izeta + 1, R=R[i])
                     orbitals.append(orb)
                     i += 1
 

--- a/src/graph2mat/core/modules/CMakeLists.txt
+++ b/src/graph2mat/core/modules/CMakeLists.txt
@@ -1,11 +1,11 @@
-#add_custom_command(
-#  OUTPUT _labels_resort.c
-#  DEPENDS _labels_resort.py
-#  VERBATIM
-#  COMMAND "${CYTHON}" "${CMAKE_CURRENT_SOURCE_DIR}/_labels_resort.py" --output-file
-#          "${CMAKE_CURRENT_BINARY_DIR}/_labels_resort.c")
-#
-#python_add_library(_labels_resort MODULE "${CMAKE_CURRENT_BINARY_DIR}/_labels_resort.c"
-#                   WITH_SOABI)
+add_custom_command(
+  OUTPUT _labels_resort.c
+  DEPENDS _labels_resort.py
+  VERBATIM
+  COMMAND "${CYTHON}" "${CMAKE_CURRENT_SOURCE_DIR}/_labels_resort.py" --output-file
+          "${CMAKE_CURRENT_BINARY_DIR}/_labels_resort.c")
 
-#install(TARGETS _labels_resort DESTINATION ${SKBUILD_PROJECT_NAME}/core/modules)
+python_add_library(_labels_resort MODULE "${CMAKE_CURRENT_BINARY_DIR}/_labels_resort.c"
+                   WITH_SOABI)
+
+install(TARGETS _labels_resort DESTINATION ${SKBUILD_PROJECT_NAME}/core/modules)

--- a/src/graph2mat/core/modules/_labels_resort.py
+++ b/src/graph2mat/core/modules/_labels_resort.py
@@ -1,44 +1,147 @@
 import numpy as np
 
 import cython
-import cython.cimports.numpy as cnp
 
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def get_edgelabels_resorting_array(edge_types: cnp.int64_t[:], sizes: cnp.int64_t[:]):
-    n_edges = edge_types.shape[0]
-    n_edge_types: cython.int = sizes.shape[0]
+def get_labels_resorting_array(
+    types: cython.integral[:],
+    shapes: cython.integral[:, :],
+    transpose_neg: cython.bint = False,
+):
+    """
+    The problem this function solves is that graph2mat executes edge/node operations
+    per edge/node type. In the case where there are 3 types, for example, you end up with
+    three arrays:
 
-    edge_type_nlabels: cnp.int64_t[:] = np.zeros(n_edge_types, dtype=int)
-    offset: cnp.int64_t[:] = np.zeros(n_edge_types, dtype=int)
+    labels_0 = [...] (n_0, x_0, y_0)
+    labels_1 = [...] (n_1, x_1, y_1)
+    labels_2 = [...] (n_2, x_2, y_2)
 
-    for i_edge in range(n_edges):
-        edge_type: cython.int = edge_types[i_edge]
+    Where n_i is the number of edges/nodes of type i, and x_i, y_i are the number of rows
+    and columns of the block of type i.
 
-        edge_type_nlabels[edge_type] += sizes[edge_type]
+    Since each type has a different block shape, they are always
+    raveled and concatenated into a single array:
 
-    # Cumsum of edge_type_nlabels
-    for edge_type in range(1, n_edge_types):
-        offset[edge_type] = offset[edge_type - 1] + edge_type_nlabels[edge_type - 1]
+    labels = np.concatenate([labels_0.ravel(), labels_1.ravel(), labels_2.ravel()])
 
-    indices: cnp.int64_t[:] = np.empty(
-        offset[n_edge_types - 1] + edge_type_nlabels[n_edge_types - 1], dtype=int
+    The labels array is of course not in the same order as the target labels.
+
+    This function receives the original order of types and then returns the indices
+    to apply to the labels array to get the correct order. I.e.:
+
+    sorted_labels = labels[indices]
+
+    Extra complication for edges
+    -----------------------------
+
+    An interesting fact is that when grouping the edges by size, there might be edges
+    in one direction and edges in the other. E.g.:
+
+    Original basis: A, B, C
+
+    where shape A == shape C != shape B. Then when grouping by size, we have:
+
+    Basis: B, (A, C)
+
+    In the target, you will always have AB and BC edges (never BA or CB). But once you
+    group, you have to face the problem that now the order is B(A, C), and therefore
+    AB edges have been reversed. That is, the predicted blocks are the transpose of
+    the target blocks.
+
+    I think this is only a problem for symmetric matrices where only
+    one direction is predicted.
+    """
+    n_entries = types.shape[0]
+    n_types: cython.int = shapes.shape[1]
+
+    type: cython.int
+    rows: cython.int
+    cols: cython.int
+    jrow: cython.int
+    jcol: cython.int
+
+    type_nlabels: cython.long[:] = np.zeros(n_types, dtype=int)
+    offset: cython.long[:] = np.zeros(n_types, dtype=int)
+
+    # Compute the sizes for each type
+    sizes: cython.int[:] = np.zeros(n_types, dtype=np.int32)
+    for type in range(n_types):
+        sizes[type] = shapes[0, type] * shapes[1, type]
+
+    # Count the number of entries of each type
+    for i_edge in range(n_entries):
+        type: cython.int = abs(types[i_edge])
+
+        type_nlabels[type] += sizes[type]
+
+    # Cumsum of type_nlabels to understand where do the labels for
+    # each type start.
+    for type in range(1, n_types):
+        offset[type] = offset[type - 1] + type_nlabels[type - 1]
+
+    # Initialize the indices array.
+    # (for each label value, index of the unsorted array where it is located)
+    indices: cython.long[:] = np.empty(
+        offset[n_types - 1] + type_nlabels[n_types - 1], dtype=int
     )
 
-    type_i: cnp.int64_t[:] = np.zeros_like(sizes, dtype=int)
+    type_i: cython.long[:] = np.zeros_like(sizes, dtype=int)
     i: cython.int = 0
 
-    for i_edge in range(n_edges):
-        edge_type = edge_types[i_edge]
+    for i_edge in range(n_entries):
+        type = types[i_edge]
+        abs_type: cython.int = abs(type)
 
-        block_size: cython.int = sizes[edge_type]
-        start: cython.int = offset[edge_type] + type_i[edge_type]
+        block_size: cython.int = sizes[abs_type]
+        start: cython.int = offset[abs_type] + type_i[abs_type]
 
-        for j in range(start, start + block_size):
-            indices[i] = j
-            i += 1
+        if transpose_neg and type < 0:
+            # Get the transposed shape
+            cols, rows = shapes[0, abs_type], shapes[1, abs_type]
+            for jrow in range(rows):
+                for jcol in range(cols):
+                    indices[i] = start + jcol * rows + jrow
+                    i += 1
 
-        type_i[edge_type] += block_size
+        else:
+            for j in range(start, start + block_size):
+                indices[i] = j
+                i += 1
+
+        type_i[abs_type] += block_size
 
     return np.asarray(indices)
+
+
+# HERE IS SOME CODE THAT COULD BE USED IN THE FUTURE TO GET RESORTING
+# INDICES WHEN basis_grouping="max". It is not used currently because
+# we just compute a mask (see Graph2Mat._get_labels_resort_index)
+
+# offsets = np.cumsum(original_sizes)
+# offsets = np.concatenate(([0], offsets))
+
+# abs_original_types = np.abs(original_types)
+
+# n_vals = original_sizes[abs_original_types].sum()
+
+# max_size = self.graph2mat_table.point_block_size[0]
+
+# indices = np.empty(n_vals, dtype=np.int64)
+# ival = 0
+# ientry = 0
+# for type in abs_original_types:
+#     # Get the start and end of the block
+#     start = offsets[type]
+#     end = offsets[type + 1]
+
+#     # Get the indices for this type
+#     indices[ival : ival + end - start] = (
+#         ientry * max_size + filters[start:end]
+#     )
+#     ival += end - start
+#     ientry += 1
+
+# return indices

--- a/src/graph2mat/tools/lightning/models/mace.py
+++ b/src/graph2mat/tools/lightning/models/mace.py
@@ -1,4 +1,4 @@
-from typing import Type, Union, Optional
+from typing import Type, Union, Optional, Literal
 
 from e3nn import o3
 from mace.modules import MACE, InteractionBlock, RealAgnosticResidualInteractionBlock
@@ -49,6 +49,7 @@ class LitMACEMatrixModel(LitBasisMatrixModel):
         correlation: int = 1,
         # unique_atoms: Sequence[sisl.Atom],
         symmetric_matrix: bool = False,
+        basis_grouping: Literal["point_type", "basis_shape", "max"] = "point_type",
         preprocessing_nodes: Optional[Type[torch.nn.Module]] = None,
         preprocessing_edges: Optional[Type[torch.nn.Module]] = None,
         preprocessing_edges_reuse_nodes: bool = True,
@@ -110,6 +111,7 @@ class LitMACEMatrixModel(LitBasisMatrixModel):
                 preprocessing_edges_reuse_nodes=preprocessing_edges_reuse_nodes,
                 node_operation=node_block_readout,
                 edge_operation=edge_block_readout,
+                basis_grouping=basis_grouping,
             )
 
         else:


### PR DESCRIPTION
Different species have different basis sizes and this complicates things when generating matrix blocks, because you need to define different functions that generate blocks of different shapes.

The most naive approach is to have one function for each block type. The number of functions that generate node blocks scales O(N) with N being the number of species. For edge blocks, the situation is even worse because the number of functions scales as O(N^2). This can backfire as a combinatorial explosion when you have many species (e.g. when developing universal models).

This commit adds the possibility to group species according to different criteria, therefore reducing the number of functions in Graph2Mat. In particular, basis_grouping="basis_shape" and "max" have been introduced. The first groups all species that have the same shape (e.g. C and O usually have the same basis shape) and the second just groups all species into one and then filters the unneeded values according to each species.

Both approaches have been tested with MACE+Graph2Mat in the full QM9 dataset and they perform a bit better than the naive approach (at constant number of parameters, that is increasing the number of parameters in the MACE model).

All in all, looking good, and graph2mat is now ready for universal models or whatever you want to throw at it!

:)