### PR TITLE
Add 'qe_spherical' basis convention for Quantum ESPRESSO compatibility

### DIFF
--- a/src/graph2mat/core/data/basis.py
+++ b/src/graph2mat/core/data/basis.py
@@ -12,6 +12,7 @@ _change_of_basis_conventions = {
     "cartesian": np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=float),
     "spherical": np.array([[0, 1, 0], [0, 0, 1], [1, 0, 0]], dtype=float),
     "siesta_spherical": np.array([[0, -1, 0], [0, 0, 1], [-1, 0, 0]], dtype=float),
+    "qe_spherical": np.array([[0, 0, 1], [-1, 0, 0], [0, -1, 0]], dtype=float),
 }
 
 for k, matrix in _change_of_basis_conventions.items():

--- a/src/graph2mat/core/data/basis.py
+++ b/src/graph2mat/core/data/basis.py
@@ -18,7 +18,7 @@ _change_of_basis_conventions = {
 for k, matrix in _change_of_basis_conventions.items():
     _change_of_basis_conventions[k] = (matrix, np.linalg.inv(matrix))
 
-BasisConvention = Literal["cartesian", "spherical", "siesta_spherical"]
+BasisConvention = Literal["cartesian", "spherical", "siesta_spherical", "qe_spherical"]
 
 
 def get_atom_basis(atom: sisl.Atom):


### PR DESCRIPTION
Quantum ESPRESSO uses a spherical harmonics ordering of z, -x, -y, which differs from existing conventions.

To improve compatibility, we added a new entry to `_change_of_basis_conventions`:

```python
"qe_spherical": np.array([[0, 0, 1], [-1, 0, 0], [0, -1, 0]], dtype=float)
