### PR TITLE
Added zipfile functionality for lightning

### DIFF
--- a/src/graph2mat/core/data/configuration.py
+++ b/src/graph2mat/core/data/configuration.py
@@ -10,23 +10,21 @@ for training, validating or testing. When doing inference, the configurations
 will not have an associated matrix, since the matrix is what you are trying
 to calculate.
 """
-
-from typing import Optional, Union, Literal, Dict, Any, Sequence
-
 import warnings
-
-from pathlib import Path
+import zipfile
 from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Literal, Optional, Sequence, Union
 
 import numpy as np
 import sisl
-from scipy.sparse import issparse, csr_array
+from scipy.sparse import csr_array, issparse
 
-from .basis import PointBasis, NoBasisAtom
-from .matrices import OrbitalMatrix, BasisMatrix, get_matrix_cls
-from .table import BasisTableWithEdges
-from .sparse import csr_to_block_dict
+from .basis import NoBasisAtom, PointBasis
 from .formats import Formats, conversions
+from .matrices import BasisMatrix, OrbitalMatrix, get_matrix_cls
+from .sparse import csr_to_block_dict
+from .table import BasisTableWithEdges
 
 Vector = np.ndarray  # [3,]
 Positions = np.ndarray  # [..., 3]
@@ -272,7 +270,7 @@ class OrbitalConfiguration(BasisConfiguration):
             return cls.from_geometry(obj, **kwargs)
         elif isinstance(obj, sisl.SparseOrbital):
             return cls.from_matrix(obj, labels=labels, **kwargs)
-        elif isinstance(obj, (str, Path)):
+        elif isinstance(obj, (str, Path, zipfile.Path)):
             if not labels:
                 kwargs["out_matrix"] = None
             return cls.from_run(obj, **kwargs)
@@ -507,7 +505,7 @@ def _sisl_run_to_orbitalconfiguration(
     # Initialize the file object for the main input file
     main_input = sisl.get_sile(runfilepath)
     # Build some metadata so that the OrbitalConfiguration object can be traced back to the run.
-    metadata = {"path": runfilepath}
+    metadata = {"path": str(runfilepath)}
 
     def _change_geometry_basis(geometry, basis):
         # new_atoms = geometry.atoms.copy()

--- a/src/graph2mat/core/data/processing.py
+++ b/src/graph2mat/core/data/processing.py
@@ -21,29 +21,29 @@ if needed.
 """
 from __future__ import annotations
 
-from typing import (
-    Optional,
-    Tuple,
-    Union,
-    Dict,
-    Any,
-    Callable,
-    Sequence,
-    Generator,
-    List,
-    Generic,
-    TypeVar,
-    Iterable,
-)
+import dataclasses
+import warnings
+import zipfile
+from copy import copy
 from functools import cached_property
 from pathlib import Path
-import dataclasses
-from copy import copy
-import warnings
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Generator,
+    Generic,
+    Iterable,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    TypeVar,
+    Union,
+)
 
-import sisl
 import numpy as np
-
+import sisl
 import torch
 
 try:
@@ -54,11 +54,11 @@ except ImportError:
         pass
 
 
-from .neighborhood import get_neighborhood
 from .configuration import BasisConfiguration, OrbitalConfiguration, PhysicsMatrixType
-from .formats import conversions, Formats
-from .table import BasisTableWithEdges
+from .formats import Formats, conversions
+from .neighborhood import get_neighborhood
 from .node_feats import OneHotZ
+from .table import BasisTableWithEdges
 
 __all__ = ["MatrixDataProcessor", "BasisMatrixData"]
 
@@ -116,7 +116,7 @@ class MatrixDataProcessor:
         }.get(self.out_matrix, self.out_matrix or Formats.SCIPY_CSR)
 
     def get_config_kwargs(self, obj: Any) -> Dict[str, Any]:
-        if isinstance(obj, (str, Path)):
+        if isinstance(obj, (str, Path, zipfile.Path)):
             kwargs = {"out_matrix": self.out_matrix}
             if hasattr(self.basis_table, "atoms"):
                 kwargs["basis"] = self.basis_table.atoms

--- a/src/graph2mat/core/data/table.py
+++ b/src/graph2mat/core/data/table.py
@@ -12,16 +12,15 @@ In a typical matrix, there will be elements that belong to connections between
 different points. Therefore, these tables also need to keep track of edge types.
 """
 
-from typing import List, Sequence, Union, Generator, Optional, Callable, Literal
-
 import itertools
-from pathlib import Path
 from io import StringIO
+from pathlib import Path
+from typing import Callable, Generator, List, Literal, Optional, Sequence, Union
 
 import numpy as np
 import sisl
 
-from .basis import PointBasis, BasisConvention, get_change_of_basis
+from .basis import BasisConvention, PointBasis, get_change_of_basis
 
 
 class BasisTableWithEdges:
@@ -616,7 +615,7 @@ class AtomicTableWithEdges(BasisTableWithEdges):
         basis = []
         # file_names = []
         # file_contents = []
-        for basis_file in sorted(basis_glob):
+        for basis_file in basis_glob:
             # TODO: Find out what to do with binary basis files formats
             # file_names.append(basis_file.name)
             # with open(basis_file, "r") as f:

--- a/src/graph2mat/tools/lightning/_helpers.py
+++ b/src/graph2mat/tools/lightning/_helpers.py
@@ -1,0 +1,218 @@
+"""To support the use of zipfiles for the data module,
+we need to have the ability of applying glob patterns inside
+the zipfile.
+
+We want to use the glob.translate function, but this is only
+available starting from Python 3.13. Until this package no
+longer supports Python 3.12, we keep here a copy of the relevant
+functions.
+
+We have:
+    - fnmatch.translate, because glob.translate depends on it
+    - glob.translate, the function that we want to use.
+"""
+
+import functools
+
+# ---------------------------------------------------
+#   CODE COPIED FROM PYTHON 3.13 GLOB AND FNMATCH
+# ---------------------------------------------------
+import os
+import re
+import zipfile
+from pathlib import Path
+from typing import Union
+
+_re_escape = functools.lru_cache(maxsize=512)(re.escape)
+
+
+def fnmatch_translate(pat, star, question_mark):
+    res = []
+    add = res.append
+    star_indices = []
+
+    i, n = 0, len(pat)
+    while i < n:
+        c = pat[i]
+        i = i + 1
+        if c == "*":
+            # store the position of the wildcard
+            star_indices.append(len(res))
+            add(star)
+            # compress consecutive `*` into one
+            while i < n and pat[i] == "*":
+                i += 1
+        elif c == "?":
+            add(question_mark)
+        elif c == "[":
+            j = i
+            if j < n and pat[j] == "!":
+                j = j + 1
+            if j < n and pat[j] == "]":
+                j = j + 1
+            while j < n and pat[j] != "]":
+                j = j + 1
+            if j >= n:
+                add("\\[")
+            else:
+                stuff = pat[i:j]
+                if "-" not in stuff:
+                    stuff = stuff.replace("\\", r"\\")
+                else:
+                    chunks = []
+                    k = i + 2 if pat[i] == "!" else i + 1
+                    while True:
+                        k = pat.find("-", k, j)
+                        if k < 0:
+                            break
+                        chunks.append(pat[i:k])
+                        i = k + 1
+                        k = k + 3
+                    chunk = pat[i:j]
+                    if chunk:
+                        chunks.append(chunk)
+                    else:
+                        chunks[-1] += "-"
+                    # Remove empty ranges -- invalid in RE.
+                    for k in range(len(chunks) - 1, 0, -1):
+                        if chunks[k - 1][-1] > chunks[k][0]:
+                            chunks[k - 1] = chunks[k - 1][:-1] + chunks[k][1:]
+                            del chunks[k]
+                    # Escape backslashes and hyphens for set difference (--).
+                    # Hyphens that create ranges shouldn't be escaped.
+                    stuff = "-".join(
+                        s.replace("\\", r"\\").replace("-", r"\-") for s in chunks
+                    )
+                i = j + 1
+                if not stuff:
+                    # Empty range: never match.
+                    add("(?!)")
+                elif stuff == "!":
+                    # Negated empty range: match any character.
+                    add(".")
+                else:
+                    # Escape set operations (&&, ~~ and ||).
+                    stuff = _re_setops_sub(r"\\\1", stuff)
+                    if stuff[0] == "!":
+                        stuff = "^" + stuff[1:]
+                    elif stuff[0] in ("^", "["):
+                        stuff = "\\" + stuff
+                    add(f"[{stuff}]")
+        else:
+            add(_re_escape(c))
+    assert i == n
+    return res, star_indices
+
+
+def translate(pat, *, recursive=False, include_hidden=False, seps=None):
+    """Translate a pathname with shell wildcards to a regular expression.
+
+    If `recursive` is true, the pattern segment '**' will match any number of
+    path segments.
+
+    If `include_hidden` is true, wildcards can match path segments beginning
+    with a dot ('.').
+
+    If a sequence of separator characters is given to `seps`, they will be
+    used to split the pattern into segments and match path separators. If not
+    given, os.path.sep and os.path.altsep (where available) are used.
+    """
+    if not seps:
+        if os.path.altsep:
+            seps = (os.path.sep, os.path.altsep)
+        else:
+            seps = os.path.sep
+    escaped_seps = "".join(map(re.escape, seps))
+    any_sep = f"[{escaped_seps}]" if len(seps) > 1 else escaped_seps
+    not_sep = f"[^{escaped_seps}]"
+    if include_hidden:
+        one_last_segment = f"{not_sep}+"
+        one_segment = f"{one_last_segment}{any_sep}"
+        any_segments = f"(?:.+{any_sep})?"
+        any_last_segments = ".*"
+    else:
+        one_last_segment = f"[^{escaped_seps}.]{not_sep}*"
+        one_segment = f"{one_last_segment}{any_sep}"
+        any_segments = f"(?:{one_segment})*"
+        any_last_segments = f"{any_segments}(?:{one_last_segment})?"
+
+    results = []
+    parts = re.split(any_sep, pat)
+    last_part_idx = len(parts) - 1
+    for idx, part in enumerate(parts):
+        if part == "*":
+            results.append(one_segment if idx < last_part_idx else one_last_segment)
+        elif recursive and part == "**":
+            if idx < last_part_idx:
+                if parts[idx + 1] != "**":
+                    results.append(any_segments)
+            else:
+                results.append(any_last_segments)
+        else:
+            if part:
+                if not include_hidden and part[0] in "*?":
+                    results.append(r"(?!\.)")
+                results.extend(fnmatch_translate(part, f"{not_sep}*", not_sep)[0])
+            if idx < last_part_idx:
+                results.append(any_sep)
+    res = "".join(results)
+    return rf"(?s:{res})\z"
+
+
+# ---------------------------------------------------
+# END OF CODE COPIED FROM PYTHON 3.13 GLOB AND FNMATCH
+# ---------------------------------------------------
+
+
+# Glob wrappers
+def _glob_zipfile(path: zipfile.ZipFile, pattern: str):
+    internal_path = Path(str(path)).relative_to(path.root.filename)
+    internal_path = str(internal_path).removeprefix("./")
+    if internal_path == ".":
+        internal_path = ""
+    if internal_path and not internal_path.endswith("/"):
+        internal_path += "/"
+
+    pattern = Path(internal_path + pattern)
+    pattern = pattern.resolve().relative_to(Path().resolve())
+
+    reg = translate(str(pattern))
+    p = re.compile(reg.replace(r"\z", r"\Z"))
+
+    fileslist = path.root.namelist()
+    return iter(zipfile.Path(path.root, s) for s in fileslist if p.match(s))
+
+
+def glob(path, pattern: str):
+    """"""
+    if isinstance(path, zipfile.Path):
+        return _glob_zipfile(path, pattern)
+    else:
+        return Path(path).glob(pattern)
+
+
+def maybe_zip_path(
+    path: Union[Path, str], zipfile_mode: str = "r"
+) -> Union[Path, zipfile.Path]:
+    path = Path(path)
+
+    for i, part in enumerate(path.parts):
+        if part.endswith(".zip"):
+            zip_path = Path(*path.parts[: i + 1])
+            if zip_path.is_file():
+                zipfile_mode = "r" if zipfile_mode.startswith("r") else "a"
+                root_zip = zipfile.ZipFile(zip_path, zipfile_mode)
+                return zipfile.Path(root_zip, str(path.relative_to(zip_path)))
+
+    return path
+
+
+def maybe_clean_zip_path(path: Union[Path, zipfile.Path]) -> Union[Path, zipfile.Path]:
+    """"""
+    if isinstance(path, zipfile.Path):
+        internal_path = (
+            Path(str(path)).resolve().relative_to(Path(path.root.filename).resolve())
+        )
+        return zipfile.Path(path.root, str(internal_path))
+    else:
+        return path

--- a/src/graph2mat/tools/lightning/model.py
+++ b/src/graph2mat/tools/lightning/model.py
@@ -1,20 +1,22 @@
 """Wrapping of raw models to use them in pytorch_lightning."""
 
-from pathlib import Path
-from typing import Type, Union, Optional
 import warnings
-
-from e3nn import o3
+import zipfile
+from pathlib import Path
+from typing import Optional, Type, Union
 
 import pytorch_lightning as pl
 import torch
+from e3nn import o3
+
+from graph2mat import AtomicTableWithEdges, BasisTableWithEdges, __version__
+from graph2mat.bindings.torch.load import sanitize_checkpoint
 
 # from context import mace
 from graph2mat.core.data.metrics import OrbitalMatrixMetric, block_type_mse
-from graph2mat import BasisTableWithEdges, AtomicTableWithEdges
-from graph2mat.bindings.torch.load import sanitize_checkpoint
 from graph2mat.core.data.node_feats import NodeFeature
-from graph2mat import __version__
+
+from ._helpers import glob, maybe_zip_path
 
 
 class LitBasisMatrixModel(pl.LightningModule):
@@ -39,12 +41,14 @@ class LitBasisMatrixModel(pl.LightningModule):
 
         self.save_hyperparameters()
 
+        root_dir = maybe_zip_path(root_dir)
+
         if basis_table is None:
             if basis_files is None:
                 self.basis_table = None
             else:
                 self.basis_table = AtomicTableWithEdges.from_basis_glob(
-                    Path(root_dir).glob(basis_files), no_basis_atoms=no_basis
+                    glob(root_dir, basis_files), no_basis_atoms=no_basis
                 )
         else:
             self.basis_table = basis_table


### PR DESCRIPTION
This PR adds the possibility of using the lightning tools (e.g. training) directly reading from inside a zip file. This is important because it means that one can just use the compressed dataset instead of needing to decompress (with the issues that this results in regarding number of files).

The zipfile functionality is based on a very recent `sisl` PR: https://github.com/zerothi/sisl/pull/914

The published datasets ([QM9](https://data.dtu.dk/articles/dataset/QM9_data_for_graph2mat/26195282), [EC](https://data.dtu.dk/articles/dataset/Ethylene_carbonate_data_for_graph2mat/26193278) and [MD17 aspirin](https://data.dtu.dk/articles/dataset/MD17_data_for_graph2mat/26195285)) will be updated from tar to zip and a new tutorial will be added to the documentation to train from those zipfiles.