### PR TITLE
Fixes docstring

### DIFF
--- a/src/graph2mat/core/data/table.py
+++ b/src/graph2mat/core/data/table.py
@@ -247,7 +247,7 @@ class BasisTableWithEdges:
     def group(
         self, grouping: Literal["basis_shape", "point_type", "max"]
     ) -> tuple["BasisTableWithEdges", np.ndarray, np.ndarray, Optional[np.ndarray]]:
-        """Groups the basis in this table and creates a new table.
+        r"""Groups the basis in this table and creates a new table.
 
         It also returns useful objects to convert between the ungrouped
         and the grouped basis tables.


### PR DESCRIPTION
Needs raw docstring to avoid syntax warning (`invalid escape sequence '\e'`)